### PR TITLE
feat: backend-core v26.8.0 프론트 마이그레이션

### DIFF
--- a/.agents/skills/queuing-api-boundary/SKILL.md
+++ b/.agents/skills/queuing-api-boundary/SKILL.md
@@ -47,10 +47,12 @@ Do not use it for purely visual CSS changes with no data flow.
 - Queue mutations must refresh `roomQueue`; playback changes must consider `roomPlayback`, and participant changes must consider `roomParticipants`.
 - A connected global STOMP client is not proof that the current socket session joined a room. After every reconnect, repeat `/app/room/{slug}/join` before restoring room topic subscriptions and invalidating room reads.
 - The current backend broker does not acknowledge a STOMP `SUBSCRIBE` receipt. Subscribe to `/user/playlist/events` before publishing room join, but do not add timing delays or retry join without an idempotency contract.
-- App-wide `/user/queue/follow-presence` must use a dedicated STOMP client instead of the room session client. A shared connection reproducibly lost `ROOM_JOINED` when follow presence was subscribed first.
+- App-wide `/user/queue/follow-presence` and room membership use dedicated clients because their ownership and reconnect lifecycles differ. Do not claim this separation fixes a room join failure unless the same authenticated account and backend state are controlled in the comparison.
 - Room route exit and a cancelled in-flight join must publish `/app/room/{slug}/leave` while the socket is connected. Do not rely on component subscription cleanup to remove the backend participant session.
+- Queue reads are infinite pages. Fetch the first page with `size`, pair every next `cursor` with that page's `queueRevision`, display `totalPendingCount`, and reset to the first page on `room.queue-mutation-conflict`.
+- `user.session-replaced` permanently stops reconnect for that room client instance without stopping the app-wide follow presence client.
 - Playlist item operations use `entryId`, not track video id.
-- Room chat messages may identify senders by `senderId` or `senderSlug` depending on API surface/version. Chat parsers and send-confirm logic must tolerate both and must not silently drop otherwise valid messages.
+- Public identity is slug-based: chat uses nullable `senderSlug`, requesters use nullable `addedBy.slug`, owners use `owner.slug`, and participants use `userSlug` plus `participantId`. Do not fall back to numeric IDs or nicknames.
 - Chat send confirmation is driven by `CHAT_MESSAGE`, but if that real-time event is missed, backfill the latest chat history before requiring a manual refresh.
 - Public room card images are currently frontend defaults. Do not assume the backend provides a representative image until the API adds it.
 

--- a/.agents/skills/queuing-qa-reviewer/SKILL.md
+++ b/.agents/skills/queuing-qa-reviewer/SKILL.md
@@ -60,8 +60,10 @@ Do not use it as a vague second implementation pass. QA must compare concrete bo
 - Any claim about a 500 or backend root cause is backed by reproducible evidence.
 - App-scoped STOMP changes are tested against room entry while the client is already active but reconnecting.
 - Room join tests prove the user-event subscribe call precedes join publish without relying on an arbitrary timing delay.
-- Auth transition QA verifies that badge SSE activation does not remount app children and that follow presence uses a different STOMP client from room membership.
+- Auth transition QA verifies that badge SSE activation does not remount app children and that follow presence remains alive when the room client is stopped by `user.session-replaced`.
 - Room reconnect tests prove join handshake -> single topic subscription -> room read invalidation order, and route cleanup proves explicit leave or cancelled-join cleanup.
+- Queue pagination tests prove first-page-only entry, cursor/revision pairing, `totalPendingCount`, conflict reset, and locked personal-order payload exclusion.
+- Account-specific failures require same-account and same-backend-state comparisons before assigning a frontend root cause.
 - Shared controls still behave consistently across home and search.
 - Hover-only controls remain reachable by focus where practical.
 - Build/lint results are reported honestly, including pre-existing warnings.

--- a/.agents/skills/queuing-ui-flow/SKILL.md
+++ b/.agents/skills/queuing-ui-flow/SKILL.md
@@ -45,9 +45,10 @@ Do not use it for API-only changes unless the UI behavior also changes.
 - Room list/card callbacks should not create per-item inline closures in parent `map` calls when the card can own the click context; pass the room/item and a stable handler into the card and bind inside the card.
 - Wheel navigation that must call `preventDefault()` must use a DOM ref plus native `addEventListener("wheel", handler, { passive: false })`; do not rely on JSX `onWheel` for scroll cancellation.
 - Text inputs or textareas that submit on Enter must ignore Enter during IME composition using `nativeEvent.isComposing`, `keyCode === 229`, or a composition ref before calling submit.
-- Queue reordering is only for the current user's pending entries unless product requirements change.
+- Queue reordering lets owners move every pending entry. Other users may move only their own `ownerOrderLocked: false` entries; locked entries stay before the free segment in server order and never enter personal reorder payloads.
 - Room reconnect UI must return to an explicit joining state, restore the backend join handshake with the saved room password, then restore chat/room subscriptions and server reads. Topic resubscription alone is not a joined room session.
 - A room screen owns cancellation of its in-flight join. Route cleanup must cancel the join and leave the room so an app-scoped socket cannot retain a ghost participant.
+- A `user.session-replaced` event is terminal for that room connection: clear room-local subscriptions/state, show the replacement message, and do not publish join again. Keep unrelated app-wide realtime clients alive.
 - CSS chip and modal sizing should be controlled in the relevant module, not by inline patching across call sites.
 - Do not introduce marketing-style landing sections for app surfaces; build the usable workflow.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,7 +36,7 @@ Next.js routes (`src/app`)
 
 - TanStack Query owns REST-backed server state.
 - STOMP subscriptions deliver real-time events; handlers must reconcile those events with query cache and screen state deliberately.
-- App-wide follow presence and room membership use separate STOMP clients. Their authentication and reconnect lifecycles are independent, and combining their user destinations on one transport has caused room join acknowledgements to be lost.
+- App-wide follow presence and room membership use separate STOMP clients because their authentication, ownership, and reconnect lifecycles are independent. A terminal room event such as `user.session-replaced` must not stop the follow presence transport.
 - Local component state owns transient UI state such as modal visibility, hover state, inputs, and local panel behavior.
 - `localStorage` is reserved for persistence that must survive navigation or reload, such as scoped room interaction state.
 

--- a/docs/agent-harness/incidents/2026-07-29-room-global-stomp-session-lifecycle.md
+++ b/docs/agent-harness/incidents/2026-07-29-room-global-stomp-session-lifecycle.md
@@ -4,7 +4,7 @@
 
 backend-core v26.7.1 프론트 마이그레이션 뒤 방 입장이 간헐적으로 5초 timeout에 걸렸고, 방 화면에 들어가도 데이터가 비어 새로고침해야 복구되는 사례가 생겼다. SPA에서 방을 나간 뒤에도 같은 WebSocket 연결에 참가자가 남는 현상도 확인했다.
 
-후속 사용자 캡처에서는 로그인 상태에서 STOMP `CONNECTED` 뒤 `/user/playlist/events`를 `SUBSCRIBE`하고 `/join`을 `SEND`했지만 `ROOM_JOINED` 없이 입장 timeout 후 `UNSUBSCRIBE`되는 흐름이 확인됐다. 비로그인 상태의 같은 방과 backend는 정상 입장했다.
+후속 사용자 캡처에서는 로그인 상태에서 STOMP `CONNECTED` 뒤 `/user/playlist/events`를 `SUBSCRIBE`하고 `/join`을 `SEND`했지만 `ROOM_JOINED` 없이 입장 timeout 후 `UNSUBSCRIBE`되는 흐름이 확인됐다. 이후 계정 A/B 검증에서 같은 컴퓨터·브라우저·프론트 커밋에서도 특정 계정(`따뜻한코러스810`)만 실패하고 다른 계정은 성공했다. 오래된 프론트 커밋에서도 동일 계정만 실패했으므로 이 증상은 프론트 변경으로 생긴 회귀가 아니었다.
 
 ## Previous Behavior
 
@@ -70,15 +70,16 @@ STOMP transport 연결과 백엔드 방 참가 세션은 서로 다른 상태다
 - 사용자 실패 캡처: `CONNECTED -> SUBSCRIBE /user/playlist/events -> SEND /join -> UNSUBSCRIBE`, `ROOM_JOINED` 없음.
 - 같은 시점 대상 방 REST meta/state는 200이었고 participants는 비어 있어 join 완료 증거가 없었다.
 - 직접 STOMP `SUBSCRIBE receipt` 요청은 `CONNECTED`만 수신하고 8초 내 `RECEIPT`를 받지 못했다.
-- Chrome에서 `/me` 성공을 주입해 로그인 전용 provider를 켜자 단일 socket의 `SUBSCRIBE follow-presence -> SUBSCRIBE playlist/events -> SEND /join` 뒤 `ROOM_JOINED`가 누락되고 timeout이 재현됐다.
-- 동일 조건에서 follow presence와 room을 별도 socket으로 분리하자 room socket이 `ROOM_JOINED`를 수신하고 playback, participants, chats, room meta가 모두 200을 반환했다.
+- 특정 계정은 배포/로컬 및 신규/과거 프론트 커밋에서 모두 실패했고, 다른 계정은 같은 컴퓨터의 동일 조건에서 성공했다.
+- 같은 실패 계정은 다른 컴퓨터에서도 증상을 비교해야 했지만, 확보된 프론트 A/B만으로도 “이번 프론트 기능 개발이 원인”이라는 가설은 기각됐다.
+- provider 주입 및 socket 분리 실험은 서로 다른 인증 상태를 완전히 통제하지 못했으므로 방 입장 실패의 인과 증거로 사용할 수 없다.
 - 비로그인에서 로그인으로 `me`가 바뀔 때 badge provider children의 mount 횟수가 1회로 유지되는 회귀 테스트를 추가했다.
 
 ## Cause or Remaining Hypotheses
 
-확정 원인은 전역 transport 재연결과 방 입장 timeout의 동일한 5초 경계, reconnect 시 join handshake 누락, route cleanup 시 leave 누락, 로그인 전용 follow presence와 room membership의 단일 STOMP client 공유, auth 전환 시 badge provider의 앱 children remount다.
+확정된 프론트 문제는 transport 연결 대기 경계, reconnect 시 join handshake 누락, route cleanup 시 leave 누락이었다. 이들은 독립적으로 수정 가치가 있지만 특정 로그인 계정의 입장 실패 원인은 아니었다.
 
-백엔드 내부에서 같은 socket의 두 user destination 중 room 응답이 누락되는 이유는 직접 관측하지 못했다. 프론트 경계에서는 shared client로 실패하고 dedicated clients로 성공하는 동일 브라우저 E2E를 확보했다.
+특정 계정 실패의 남은 가설은 백엔드의 계정별 방 참가/session 상태다. 프론트에서 participant polling, 강제 새로고침, 임의 지연을 추가해 우회하면 원인을 숨기고 정상 계정의 흐름만 복잡하게 만들므로 제거했다.
 
 별도 잔여 이슈로 모바일 viewport에서 기존 `useMediaQuery` 초기값 때문에 home hydration mismatch가 재현됐다. 이 현상은 이번 PR diff 이전부터 존재하며 방 세션 수정과는 별도 범위다.
 
@@ -92,7 +93,7 @@ STOMP transport 연결과 백엔드 방 참가 세션은 서로 다른 상태다
 
 ## Chosen Solution and Rationale
 
-기본 방 세션 복구에는 option 3을 적용했다. 로그인 상태의 후속 충돌에는 option 5를 적용했다. presence는 로그인 user slug 생명주기, room은 route와 room membership 생명주기를 가지므로 별도 transport가 책임 경계와 실제 backend 동작에 맞다.
+기본 방 세션 복구에는 option 3을 적용했다. presence와 room 연결 분리는 서로 다른 생명주기를 격리하는 구조적 선택으로 유지하되, 특정 계정의 입장 실패를 고친 증거로 주장하지 않는다.
 
 250ms 안정화는 영향 사용자 재검증에서 실패했고 같은 연결의 user destination 충돌을 해결하지 못해 제거했다. join 재전송도 backend idempotency 계약이 없어 선택하지 않았다.
 
@@ -109,7 +110,7 @@ STOMP transport 연결과 백엔드 방 참가 세션은 서로 다른 상태다
 
 ## Reusable Rule
 
-Global presence transport state and room membership state must be modeled separately and use separate clients when their user destinations conflict. Every new room socket session needs a join handshake; topic cleanup is not a leave handshake. Auth-dependent providers must not change the wrapper identity of the app children they observe. Do not replace a reproduced lifecycle conflict with arbitrary delays or unsafe join retries.
+Global presence transport state and room membership state must be modeled separately when their owners and terminal states differ. Every new room socket session needs a join handshake; topic cleanup is not a leave handshake. Auth-dependent providers must not change the wrapper identity of the app children they observe. For account-specific failures, compare the same account across frontend versions before attributing causality; do not add polling, hard reloads, arbitrary delays, or unsafe join retries as diagnostic leftovers.
 
 ## Skill or Team Spec Updates
 
@@ -122,7 +123,7 @@ Global presence transport state and room membership state must be modeled separa
 
 - focused Vitest: 3 files / 7 tests pass
 - before-fix authenticated-provider Chrome E2E: `room.join-timeout` reproduced
-- after-fix authenticated-provider Chrome E2E: `/home` render and public room `ROOM_JOINED`/REST reads pass
+- after-fix authenticated-provider Chrome E2E는 검증에 사용한 계정에서는 통과했지만, 특정 실패 계정 문제 해결의 증거는 아님
 - full Vitest 33 files / 87 tests, lint, build, diff check: pass
 - fresh read-only QA: pass
-- actual Google OAuth user session after-change: pending user recheck
+- 후속 계정 A/B: 특정 계정만 과거/현재 프론트 모두 실패하여 프론트 회귀 가설 기각

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/api-contract.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/api-contract.md
@@ -1,0 +1,29 @@
+# API Contract
+
+## Queue Pages
+
+- first: `size=100`
+- next: previous `nextCursor`, previous `queueRevision`, `size=100`
+- response: `items`, `hasNext`, `nextCursor`, `queueRevision`, `totalPendingCount`
+- conflict: clear pages and restart from first page
+
+## Public Identity
+
+- participant list key: `participantId`; logged-in identity: `userSlug`
+- owner identity: `owner.slug`
+- queue requester identity: `addedBy.slug`
+- chat identity: `senderSlug`
+- no numeric id or nickname fallback
+
+## Join
+
+- event requires `type`, `roomSlug`, `timestamp`, `data`
+- accepted types: `ROOM_JOINED`, `ERROR`
+- private/not-found failure: `room.access-denied`
+- session replacement: `user.session-replaced`
+
+## Thumbnail
+
+- responsive keys: `thumb256`, `thumb384`, `thumb640`, `thumb828`, `thumb1200`
+- track thumbnail is nullable
+- temporary upload metadata fields are required

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/delivery-state.md
@@ -1,12 +1,12 @@
 # Delivery State
 
-- status: publishing
+- status: published
 - branch: feat/backend-core-v26-8-0
 - base: feat/backend-core-v26-7-1
 - issue:
-- pr:
+- pr: https://github.com/Queuing-org/frontend/pull/29
 - selected_skills: queuing-feature-delivery, queuing-orchestrator, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-incident-curator, queuing-qa-reviewer
 - local_qa: test 42 files / 100 tests pass; lint pass; build pass
 - ci: pending
 - review_threads: none
-- next_action: 기능 단위 commit 후 push하고 stacked Draft PR을 생성한다.
+- next_action: PR #29 CI와 backend v26.8 수동 다중 창 QA를 확인한다.

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/delivery-state.md
@@ -1,0 +1,12 @@
+# Delivery State
+
+- status: publishing
+- branch: feat/backend-core-v26-8-0
+- base: feat/backend-core-v26-7-1
+- issue:
+- pr:
+- selected_skills: queuing-feature-delivery, queuing-orchestrator, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-incident-curator, queuing-qa-reviewer
+- local_qa: test 42 files / 100 tests pass; lint pass; build pass
+- ci: pending
+- review_threads: none
+- next_action: 기능 단위 commit 후 push하고 stacked Draft PR을 생성한다.

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/handoff.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/handoff.md
@@ -2,6 +2,7 @@
 
 - branch: `feat/backend-core-v26-8-0`
 - base: `feat/backend-core-v26-7-1`
+- draft PR: https://github.com/Queuing-org/frontend/pull/29
 - implementation: complete
 - automated QA: test/lint/build pass
 - fresh QA: pass after participant legacy slug fallback removal

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/handoff.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/handoff.md
@@ -1,0 +1,8 @@
+# Handoff
+
+- branch: `feat/backend-core-v26-8-0`
+- base: `feat/backend-core-v26-7-1`
+- implementation: complete
+- automated QA: test/lint/build pass
+- fresh QA: pass after participant legacy slug fallback removal
+- next: commit by feature slices, push, and open a stacked Draft PR

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/plan.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/plan.md
@@ -1,0 +1,66 @@
+# backend-core v26.8.0 프론트 마이그레이션
+
+## Scope
+
+- 기준 문서: 사용자 제공 `backend-core v26.8.0-beta.1` 프론트 변경 안내
+- 기준 브랜치: `feat/backend-core-v26-7-1@185e17a`
+- 작업 브랜치: `feat/backend-core-v26-8-0`
+- queue 구간 조회, 고정곡 순서, 공개 식별자, join/access 오류, session replacement, thumbnail 계약을 반영한다.
+- 특정 계정의 백엔드 상태 문제를 프론트 문제로 오인해 추가한 방 입장 polling/강제 navigation/근거 없는 실시간 충돌 우회와 문서 주장을 제거한다.
+
+## Selected Skills
+
+- `queuing-feature-delivery`
+- `queuing-orchestrator`
+- `queuing-api-boundary`
+- `queuing-ui-flow`
+- `frontend-architecture-guardrails`
+- `queuing-incident-curator`
+- `queuing-qa-reviewer`
+
+## Ownership
+
+- queue 페이지 서버 상태: TanStack infinite query
+- queue 다음 구간 로드와 탭 수량: room queue panel hook
+- 개인 순서 제한/오류: queue reorder domain helper와 sortable UI
+- room session replacement: room-scoped realtime hook
+- app-wide follow presence: 전용 STOMP client, room session 종료와 독립
+- 공개 식별: backend 응답의 `participantId`, `userSlug`, `slug`만 사용
+
+## Commit Slices
+
+1. `feat(api): v26.8.0 페이지와 공개 식별 계약 반영`
+2. `feat(queue): 구간 조회와 고정곡 순서 UI 반영`
+3. `feat(realtime): 대체된 방 세션의 재접속 중단`
+4. `docs: 잘못된 방 입장 진단과 v26.8.0 QA 기록 정정`
+
+## Acceptance Criteria
+
+- queue는 첫 페이지만 진입 시 읽고 cursor+queueRevision으로 다음 페이지를 명시적으로 읽는다.
+- queue conflict는 캐시를 비우고 첫 페이지부터 다시 시작한다.
+- 탭 수는 `totalPendingCount`를 사용한다.
+- 일반 사용자는 owner locked 곡을 움직이거나 reorder payload에 포함하지 않는다.
+- rooms API는 `lastId` legacy 경로를 전송하지 않는다.
+- participant/owner/addedBy/chat는 공개 식별 필드만 사용한다.
+- join event는 필수 `roomSlug`, `timestamp`를 검증하고 `room.access-denied`만 처리한다.
+- `user.session-replaced`를 받은 해당 방은 재접속하지 않고 지정 문구를 표시한다.
+- thumbnail/track image nullable 계약을 반영한다.
+- 진단용 참가자 REST polling과 OAuth hard navigation은 제거한다.
+- `npm run lint`, `npm run test`, `npm run build`, fresh QA가 통과한다.
+
+## Progress
+
+- [x] 브랜치 생성
+- [x] 실행 계획 생성
+- [x] API/타입 변경
+- [x] queue UI/상태 변경
+- [x] session replacement 변경
+- [x] 잘못된 진단 코드/문서 정리
+- [x] targeted/full QA
+- [x] 기능 단위 commit
+- [ ] push/Draft PR
+
+## Residual Risk
+
+- 실제 동일 계정 다중 창 session replacement는 backend v26.8.0 환경이 필요하다.
+- stacked branch이므로 v26.7.1 Draft PR의 병합 순서에 의존한다.

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/plan.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/plan.md
@@ -58,7 +58,7 @@
 - [x] 잘못된 진단 코드/문서 정리
 - [x] targeted/full QA
 - [x] 기능 단위 commit
-- [ ] push/Draft PR
+- [x] push/Draft PR
 
 ## Residual Risk
 

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/qa-report.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/qa-report.md
@@ -1,0 +1,32 @@
+# QA Report
+
+## Automated Gates
+
+- `npm run test`: pass, 42 files / 100 tests
+- `npm run lint`: pass, warnings 0
+- `npm run build`: pass, Next.js production build and 8 routes generated
+- `git diff --check`: pass
+
+## Contract Coverage
+
+- queue first/next page request pairing and `totalPendingCount`
+- next-page `room.queue-mutation-conflict` reset to a single fresh first page
+- infinite-page optimistic reorder/delete cache shape
+- owner locked personal-order exclusion and disabled UI
+- room list cursor-only request without legacy `lastId`
+- strict join event fields and removal of `ROOM_JOIN_FAILED`
+- unified `room.access-denied`
+- same-room `user.session-replaced` terminal cleanup and different-room ignore
+- public participant/requester/chat identity without numeric/nickname fallback
+- nullable track thumbnail fallback and required temporary upload metadata
+
+## Manual / Environment-dependent
+
+- Actual same-account multi-window replacement requires a v26.8 backend session and remains manual QA.
+- The specific `따뜻한코러스810` room-entry failure reproduced on old and new frontend commits; frontend-regression causality is rejected and the incident record is corrected.
+
+## Fresh Review
+
+- independent read-only QA: pass after fixing one finding
+- finding fixed: participant identity helper no longer falls back from `userSlug` to an extra legacy `slug` field
+- residual: real backend multi-window event and pointer-level DnD remain manual QA

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/request-summary.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/request-summary.md
@@ -1,0 +1,8 @@
+# Request Summary
+
+- backend-core v26.8.0-beta.1 프론트 변경 안내 전체를 반영한다.
+- queue 전체 선조회 대신 구간 조회와 `totalPendingCount`를 사용한다.
+- owner locked 개인 곡 이동을 금지한다.
+- rooms legacy `lastId`와 비공개 식별 fallback을 제거한다.
+- join/access/session replacement/thumbnail 계약을 엄격히 적용한다.
+- 특정 계정 백엔드 상태 문제를 해결하려고 추가했던 프론트 방 입장 우회 코드를 제거한다.

--- a/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/ui-flow.md
+++ b/docs/exec-plans/active/2026-08-02-backend-core-v26-8-0/ui-flow.md
@@ -1,0 +1,22 @@
+# UI Flow
+
+## Queue Pagination
+
+- room entry loads one page per queue tab query.
+- explicit load-more interaction appends the next page.
+- tab count renders `totalPendingCount`, independent of loaded item count.
+- conflict discards stale pages and returns to the first page.
+
+## Personal Reorder
+
+- locked entries remain first in server order and render disabled move affordances.
+- reorder payload includes only unlocked own pending entries.
+- single move requires both moving and anchor entries to be unlocked.
+- backend reorder errors render their server message in the reorder surface.
+
+## Session Replacement
+
+- stop room reconnect for the replaced room.
+- clear room/chat subscriptions and transient room state.
+- retain the independent app-wide follow presence connection.
+- render `현재 방은 다른 창에서 마지막으로 열렸습니다.`

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -3,5 +3,6 @@
 - `2026-07-12-profile-stats-moderation`: ci-pending — PR #26 리뷰 대응 완료, CodeRabbit 재검토 대기
 - `2026-07-25-preupload-room-thumbnail`: ready — PR #27 태그 최대 3개 후속 변경 및 CI 통과, human review 대기
 - `2026-07-29-backend-core-v26-7-1`: ci-pending — Draft PR #28, backend-core v26.7.1 전체 프론트 마이그레이션
+- `2026-08-02-backend-core-v26-8-0`: implementing — v26.8.0 구간 queue, 공개 식별자, session replacement 계약
 
 When a run starts, list its directory, status, and purpose here. Remove the entry when the run moves to `../completed/`.

--- a/src/features/playlist/api/fetchRoomQueue.ts
+++ b/src/features/playlist/api/fetchRoomQueue.ts
@@ -7,11 +7,29 @@ import { normalizeRoomSlug } from "@/src/shared/lib/normalizeRoomSlug";
 import type {
   RoomQueuePage,
   RoomQueueRequestParams,
-  RoomQueueResult,
 } from "../model/types";
 
 const QUEUE_PAGE_SIZE = 100;
-const QUEUE_CONFLICT_CODE = "room.queue-mutation-conflict";
+export const QUEUE_CONFLICT_CODE = "room.queue-mutation-conflict";
+
+export function getNextRoomQueuePageParam(page: RoomQueuePage) {
+  if (!page.hasNext) {
+    return undefined;
+  }
+
+  if (!page.nextCursor) {
+    throw new ApiError({
+      status: 500,
+      code: "invalid-queue-page",
+      message: "다음 큐 페이지 커서가 없습니다.",
+    });
+  }
+
+  return {
+    cursor: page.nextCursor,
+    queueRevision: page.queueRevision,
+  };
+}
 
 export async function fetchRoomQueuePage({
   slug,
@@ -36,56 +54,4 @@ export async function fetchRoomQueuePage({
   );
 
   return unwrapApiResponse(res.data);
-}
-
-async function fetchEveryQueuePage(
-  params: PlaylistProtectedParams,
-): Promise<RoomQueueResult> {
-  const items: RoomQueueResult = [];
-  let cursor: string | null = null;
-  let queueRevision: number | null = null;
-
-  do {
-    const page = await fetchRoomQueuePage({
-      ...params,
-      cursor,
-      queueRevision,
-      size: QUEUE_PAGE_SIZE,
-    });
-    items.push(...page.items);
-
-    if (!page.hasNext) {
-      return items;
-    }
-
-    if (!page.nextCursor) {
-      throw new ApiError({
-        status: 500,
-        code: "invalid-queue-page",
-        message: "다음 큐 페이지 커서가 없습니다.",
-      });
-    }
-
-    cursor = page.nextCursor;
-    queueRevision = page.queueRevision;
-  } while (true);
-}
-
-type PlaylistProtectedParams = Pick<
-  RoomQueueRequestParams,
-  "slug" | "password" | "mine"
->;
-
-export async function fetchRoomQueue(
-  params: PlaylistProtectedParams,
-): Promise<RoomQueueResult> {
-  try {
-    return await fetchEveryQueuePage(params);
-  } catch (error) {
-    if (!(error instanceof ApiError) || error.code !== QUEUE_CONFLICT_CODE) {
-      throw error;
-    }
-
-    return fetchEveryQueuePage(params);
-  }
 }

--- a/src/features/playlist/api/roomReads.test.ts
+++ b/src/features/playlist/api/roomReads.test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError } from "@/src/shared/api/api-error";
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
 import { fetchRoomHistory } from "./fetchRoomHistory";
 import { fetchRoomParticipants } from "./fetchRoomParticipants";
 import { fetchRoomPlayback } from "./fetchRoomPlayback";
-import { fetchRoomQueue } from "./fetchRoomQueue";
+import { fetchRoomQueuePage } from "./fetchRoomQueue";
 
 vi.mock("@/src/shared/api/axiosInstance", () => ({
   axiosInstance: { get: vi.fn() },
@@ -25,14 +24,19 @@ const queueEntry = (entryId: string) => ({
     durationMs: 1000,
     thumbnailUrl: "https://example.com/thumbnail.jpg",
   },
-  status: { skipped: false, isActive: false, isPlayed: false },
-  addedBy: { nickname: "신청자", slug: "requester" },
+  status: {
+    skipped: false,
+    isActive: false,
+    isPlayed: false,
+    ownerOrderLocked: false,
+  },
+  addedBy: { nickname: "신청자", slug: "requester", avatarUrl: null },
   entryId,
   createdAtMs: 1,
   updatedAtMs: 1,
 });
 
-describe("v26.7.1 방 조회 API", () => {
+describe("v26.8.0 방 조회 API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -46,6 +50,7 @@ describe("v26.7.1 방 조회 API", () => {
             hasNext: true,
             nextCursor: "entry-1",
             queueRevision: 12,
+            totalPendingCount: 2,
           },
         },
       })
@@ -56,13 +61,20 @@ describe("v26.7.1 방 조회 API", () => {
             hasNext: false,
             nextCursor: null,
             queueRevision: 12,
+            totalPendingCount: 2,
           },
         },
       });
 
     await expect(
-      fetchRoomQueue({ slug: "room", password: "secret" }),
-    ).resolves.toHaveLength(2);
+      fetchRoomQueuePage({ slug: "room", password: "secret" }),
+    ).resolves.toMatchObject({ totalPendingCount: 2 });
+    await fetchRoomQueuePage({
+      slug: "room",
+      password: "secret",
+      cursor: "entry-1",
+      queueRevision: 12,
+    });
 
     expect(axiosInstance.get).toHaveBeenNthCalledWith(
       1,
@@ -84,46 +96,6 @@ describe("v26.7.1 방 조회 API", () => {
         headers: { "X-Room-Password": "secret" },
       },
     );
-  });
-
-  it("페이지 조회 중 queue conflict가 발생하면 첫 페이지부터 한 번 재시작한다", async () => {
-    const firstPage = {
-      data: {
-        result: {
-          items: [queueEntry("entry-1")],
-          hasNext: true,
-          nextCursor: "entry-1",
-          queueRevision: 12,
-        },
-      },
-    };
-    vi.mocked(axiosInstance.get)
-      .mockResolvedValueOnce(firstPage)
-      .mockRejectedValueOnce(
-        new ApiError({
-          status: 409,
-          code: "room.queue-mutation-conflict",
-          message: "conflict",
-        }),
-      )
-      .mockResolvedValueOnce({
-        data: {
-          result: {
-            items: [queueEntry("entry-new")],
-            hasNext: false,
-            nextCursor: null,
-            queueRevision: 13,
-          },
-        },
-      });
-
-    await expect(fetchRoomQueue({ slug: "room" })).resolves.toEqual([
-      queueEntry("entry-new"),
-    ]);
-    expect(axiosInstance.get).toHaveBeenCalledTimes(3);
-    expect(vi.mocked(axiosInstance.get).mock.calls[2]?.[1]).toMatchObject({
-      params: { size: 100 },
-    });
   });
 
   it("playback 응답을 분리된 현재 재생 객체로 파싱한다", async () => {
@@ -152,7 +124,13 @@ describe("v26.7.1 방 조회 API", () => {
       .mockResolvedValueOnce({
         data: {
           result: {
-            items: [{ nickname: "A", participantId: "a" }],
+            items: [{
+              nickname: "A",
+              participantId: "a",
+              participantType: "GUEST",
+              userSlug: null,
+              profileImageUrl: null,
+            }],
             hasNext: true,
             nextCursor: "a",
           },
@@ -161,7 +139,13 @@ describe("v26.7.1 방 조회 API", () => {
       .mockResolvedValueOnce({
         data: {
           result: {
-            items: [{ nickname: "B", participantId: "b" }],
+            items: [{
+              nickname: "B",
+              participantId: "b",
+              participantType: "GUEST",
+              userSlug: null,
+              profileImageUrl: null,
+            }],
             hasNext: false,
             nextCursor: null,
           },

--- a/src/features/playlist/model/queueOrderOptimistic.test.ts
+++ b/src/features/playlist/model/queueOrderOptimistic.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { PlaylistEntry } from "./types";
+import { applyPendingEntryOrder, type RoomQueueData } from "./queueOrderOptimistic";
+
+const entry = (entryId: string, ownerOrderLocked: boolean): PlaylistEntry => ({
+  order: 1,
+  track: {
+    title: entryId,
+    videoId: entryId,
+    provider: "YOUTUBE",
+    durationMs: 1,
+    thumbnailUrl: null,
+  },
+  status: {
+    skipped: false,
+    isActive: false,
+    isPlayed: false,
+    ownerOrderLocked,
+  },
+  addedBy: { slug: "me", nickname: "나", avatarUrl: null },
+  entryId,
+  createdAtMs: 1,
+  updatedAtMs: 1,
+});
+
+describe("queueOrderOptimistic", () => {
+  it("개인 자유 구간만 재정렬하면 고정곡 위치와 페이지 구조를 보존한다", () => {
+    const data: RoomQueueData = {
+      pages: [
+        {
+          items: [entry("locked", true), entry("a", false)],
+          hasNext: true,
+          nextCursor: "a",
+          queueRevision: 1,
+          totalPendingCount: 3,
+        },
+        {
+          items: [entry("b", false)],
+          hasNext: false,
+          nextCursor: null,
+          queueRevision: 1,
+          totalPendingCount: 3,
+        },
+      ],
+      pageParams: [null, { cursor: "a", queueRevision: 1 }],
+    };
+
+    const result = applyPendingEntryOrder(data, ["b", "a"]);
+    expect(result?.pages.map((page) => page.items.map((item) => item.entryId)))
+      .toEqual([["locked", "b"], ["a"]]);
+    expect(result?.pages[0]?.items[0]?.status.ownerOrderLocked).toBe(true);
+  });
+});

--- a/src/features/playlist/model/queueOrderOptimistic.ts
+++ b/src/features/playlist/model/queueOrderOptimistic.ts
@@ -1,14 +1,22 @@
-import type { RoomQueueResult } from "./types";
+import type { InfiniteData } from "@tanstack/react-query";
+import type { RoomQueuePage, RoomQueuePageParam } from "./types";
 
-export type QueueOrderSnapshot = [readonly unknown[], RoomQueueResult | undefined];
+export type RoomQueueData = InfiniteData<
+  RoomQueuePage,
+  RoomQueuePageParam | null
+>;
+
+export type QueueOrderSnapshot = [readonly unknown[], RoomQueueData | undefined];
 
 export function applyPendingEntryOrder(
-  currentEntries: RoomQueueResult | undefined,
+  currentData: RoomQueueData | undefined,
   orderedPendingEntryIds: string[],
 ) {
-  if (!currentEntries || orderedPendingEntryIds.length < 2) {
-    return currentEntries;
+  if (!currentData || orderedPendingEntryIds.length < 2) {
+    return currentData;
   }
+
+  const currentEntries = currentData.pages.flatMap((page) => page.items);
 
   const orderedEntriesById = new Map(
     currentEntries
@@ -20,12 +28,12 @@ export function applyPendingEntryOrder(
     .filter((entry) => !!entry);
 
   if (reorderedEntries.length !== orderedPendingEntryIds.length) {
-    return currentEntries;
+    return currentData;
   }
 
   let reorderedIndex = 0;
 
-  return currentEntries.map((entry) => {
+  const nextEntries = currentEntries.map((entry) => {
     if (!orderedEntriesById.has(entry.entryId)) {
       return entry;
     }
@@ -35,4 +43,41 @@ export function applyPendingEntryOrder(
 
     return reorderedEntry ?? entry;
   });
+
+  let nextEntryIndex = 0;
+  return {
+    ...currentData,
+    pages: currentData.pages.map((page) => ({
+      ...page,
+      items: page.items.map(() => {
+        const entry = nextEntries[nextEntryIndex];
+        nextEntryIndex += 1;
+        return entry;
+      }),
+    })),
+  };
+}
+
+export function removeQueueEntries(
+  currentData: RoomQueueData | undefined,
+  entryIds: ReadonlySet<string>,
+) {
+  if (!currentData) {
+    return currentData;
+  }
+
+  const removedCount = currentData.pages.reduce(
+    (count, page) =>
+      count + page.items.filter((entry) => entryIds.has(entry.entryId)).length,
+    0,
+  );
+
+  return {
+    ...currentData,
+    pages: currentData.pages.map((page) => ({
+      ...page,
+      items: page.items.filter((entry) => !entryIds.has(entry.entryId)),
+      totalPendingCount: Math.max(0, page.totalPendingCount - removedCount),
+    })),
+  };
 }

--- a/src/features/playlist/model/types.ts
+++ b/src/features/playlist/model/types.ts
@@ -49,20 +49,20 @@ export type PlaylistTrack = {
   videoId: string;
   provider: TrackProvider;
   durationMs: number;
-  thumbnailUrl: string;
+  thumbnailUrl: string | null;
 };
 
 export type PlaylistEntryStatus = {
   skipped: boolean;
   isActive: boolean;
   isPlayed: boolean;
+  ownerOrderLocked: boolean;
 };
 
 export type PlaylistAddedBy = {
-  slug?: string | null;
-  userId?: number | null;
+  slug: string | null;
   nickname: string;
-  avatarUrl?: string | null;
+  avatarUrl: string | null;
 };
 
 export type PlaylistEntry = {
@@ -76,16 +76,12 @@ export type PlaylistEntry = {
   updatedAtMs: number;
 };
 
-export type RoomQueueResult = PlaylistEntry[];
-
 export type PlaylistParticipant = {
-  participantType?: "USER" | "GUEST" | (string & {});
-  participantId?: string | null;
-  userSlug?: string | null;
-  slug?: string | null;
-  userId?: number | null;
+  participantType: "USER" | "GUEST";
+  participantId: string;
+  userSlug: string | null;
   nickname: string;
-  profileImageUrl?: string | null;
+  profileImageUrl: string | null;
 };
 
 export type PlaybackPosition = {
@@ -106,6 +102,12 @@ export type RoomQueuePage = {
   items: PlaylistEntry[];
   hasNext: boolean;
   nextCursor: string | null;
+  queueRevision: number;
+  totalPendingCount: number;
+};
+
+export type RoomQueuePageParam = {
+  cursor: string;
   queueRevision: number;
 };
 

--- a/src/features/playlist/model/useDeleteMyQueueEntry.ts
+++ b/src/features/playlist/model/useDeleteMyQueueEntry.ts
@@ -2,14 +2,15 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteMyQueueEntry } from "../api/deleteMyQueueEntry";
-import type {
-  DeleteMyQueueEntryParams,
-  RoomQueueResult,
-} from "./types";
+import type { DeleteMyQueueEntryParams } from "./types";
 import type { ApiError } from "@/src/shared/api/api-error";
+import {
+  removeQueueEntries,
+  type RoomQueueData,
+} from "./queueOrderOptimistic";
 import { playlistKeys } from "./queryKeys";
 
-type RoomQueueSnapshot = [readonly unknown[], RoomQueueResult | undefined];
+type RoomQueueSnapshot = [readonly unknown[], RoomQueueData | undefined];
 
 export function useDeleteMyQueueEntry() {
   const queryClient = useQueryClient();
@@ -24,14 +25,13 @@ export function useDeleteMyQueueEntry() {
       });
 
       const previousRoomQueueSnapshots =
-        queryClient.getQueriesData<RoomQueueResult>({
+        queryClient.getQueriesData<RoomQueueData>({
           queryKey: playlistKeys.roomQueuePrefix(slug),
         });
 
-      queryClient.setQueriesData<RoomQueueResult>(
+      queryClient.setQueriesData<RoomQueueData>(
         { queryKey: playlistKeys.roomQueuePrefix(slug) },
-        (currentEntries) =>
-          currentEntries?.filter((entry) => entry.entryId !== entryId),
+        (currentData) => removeQueueEntries(currentData, new Set([entryId])),
       );
 
       return { previousRoomQueueSnapshots };
@@ -46,7 +46,7 @@ export function useDeleteMyQueueEntry() {
       });
     },
     onSuccess: async (_result, variables) => {
-      await queryClient.invalidateQueries({
+      await queryClient.resetQueries({
         queryKey: playlistKeys.roomQueuePrefix(variables.slug),
       });
       await queryClient.invalidateQueries({

--- a/src/features/playlist/model/useDeleteRoomQueueEntries.ts
+++ b/src/features/playlist/model/useDeleteRoomQueueEntries.ts
@@ -2,14 +2,15 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteRoomQueueEntries } from "../api/deleteRoomQueueEntries";
-import type {
-  DeleteRoomQueueEntriesParams,
-  RoomQueueResult,
-} from "./types";
+import type { DeleteRoomQueueEntriesParams } from "./types";
 import type { ApiError } from "@/src/shared/api/api-error";
+import {
+  removeQueueEntries,
+  type RoomQueueData,
+} from "./queueOrderOptimistic";
 import { playlistKeys } from "./queryKeys";
 
-type RoomQueueSnapshot = [readonly unknown[], RoomQueueResult | undefined];
+type RoomQueueSnapshot = [readonly unknown[], RoomQueueData | undefined];
 
 export function useDeleteRoomQueueEntries() {
   const queryClient = useQueryClient();
@@ -24,15 +25,14 @@ export function useDeleteRoomQueueEntries() {
       });
 
       const previousRoomQueueSnapshots =
-        queryClient.getQueriesData<RoomQueueResult>({
+        queryClient.getQueriesData<RoomQueueData>({
           queryKey: playlistKeys.roomQueuePrefix(slug),
         });
 
       const entryIdSet = new Set(entryIds);
-      queryClient.setQueriesData<RoomQueueResult>(
+      queryClient.setQueriesData<RoomQueueData>(
         { queryKey: playlistKeys.roomQueuePrefix(slug) },
-        (currentEntries) =>
-          currentEntries?.filter((entry) => !entryIdSet.has(entry.entryId)),
+        (currentData) => removeQueueEntries(currentData, entryIdSet),
       );
 
       return { previousRoomQueueSnapshots };
@@ -47,7 +47,7 @@ export function useDeleteRoomQueueEntries() {
       });
     },
     onSuccess: async (_result, variables) => {
-      await queryClient.invalidateQueries({
+      await queryClient.resetQueries({
         queryKey: playlistKeys.roomQueuePrefix(variables.slug),
       });
       await queryClient.invalidateQueries({

--- a/src/features/playlist/model/useMoveMyQueueEntry.ts
+++ b/src/features/playlist/model/useMoveMyQueueEntry.ts
@@ -2,11 +2,12 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { moveMyQueueEntry } from "../api/moveMyQueueEntry";
-import type { MoveMyQueueEntryParams, RoomQueueResult } from "./types";
+import type { MoveMyQueueEntryParams } from "./types";
 import type { ApiError } from "@/src/shared/api/api-error";
 import {
   applyPendingEntryOrder,
   type QueueOrderSnapshot,
+  type RoomQueueData,
 } from "./queueOrderOptimistic";
 import { playlistKeys } from "./queryKeys";
 
@@ -33,11 +34,11 @@ export function useMoveMyQueueEntry() {
       });
 
       const previousRoomQueueSnapshots =
-        queryClient.getQueriesData<RoomQueueResult>({
+        queryClient.getQueriesData<RoomQueueData>({
           queryKey: playlistKeys.roomQueuePrefix(slug),
         });
 
-      queryClient.setQueriesData<RoomQueueResult>(
+      queryClient.setQueriesData<RoomQueueData>(
         { queryKey: playlistKeys.roomQueuePrefix(slug) },
         (currentEntries) =>
           applyPendingEntryOrder(currentEntries, orderedPendingEntryIds),
@@ -55,7 +56,7 @@ export function useMoveMyQueueEntry() {
       });
     },
     onSuccess: async (_result, variables) => {
-      await queryClient.invalidateQueries({
+      await queryClient.resetQueries({
         queryKey: playlistKeys.roomQueuePrefix(variables.slug),
       });
       await queryClient.invalidateQueries({

--- a/src/features/playlist/model/useMoveRoomQueueEntry.ts
+++ b/src/features/playlist/model/useMoveRoomQueueEntry.ts
@@ -2,11 +2,12 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { moveRoomQueueEntry } from "../api/moveRoomQueueEntry";
-import type { MoveRoomQueueEntryParams, RoomQueueResult } from "./types";
+import type { MoveRoomQueueEntryParams } from "./types";
 import type { ApiError } from "@/src/shared/api/api-error";
 import {
   applyPendingEntryOrder,
   type QueueOrderSnapshot,
+  type RoomQueueData,
 } from "./queueOrderOptimistic";
 import { playlistKeys } from "./queryKeys";
 
@@ -33,11 +34,11 @@ export function useMoveRoomQueueEntry() {
       });
 
       const previousRoomQueueSnapshots =
-        queryClient.getQueriesData<RoomQueueResult>({
+        queryClient.getQueriesData<RoomQueueData>({
           queryKey: playlistKeys.roomQueuePrefix(slug),
         });
 
-      queryClient.setQueriesData<RoomQueueResult>(
+      queryClient.setQueriesData<RoomQueueData>(
         { queryKey: playlistKeys.roomQueuePrefix(slug) },
         (currentEntries) =>
           applyPendingEntryOrder(currentEntries, orderedPendingEntryIds),
@@ -55,7 +56,7 @@ export function useMoveRoomQueueEntry() {
       });
     },
     onSuccess: async (_result, variables) => {
-      await queryClient.invalidateQueries({
+      await queryClient.resetQueries({
         queryKey: playlistKeys.roomQueuePrefix(variables.slug),
       });
       await queryClient.invalidateQueries({

--- a/src/features/playlist/model/useMyRoomQueue.test.tsx
+++ b/src/features/playlist/model/useMyRoomQueue.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/src/shared/api/api-error";
+import { fetchRoomQueuePage } from "../api/fetchRoomQueue";
+import { useMyRoomQueue } from "./useMyRoomQueue";
+
+vi.mock("../api/fetchRoomQueue", () => ({
+  fetchRoomQueuePage: vi.fn(),
+  getNextRoomQueuePageParam: (lastPage: {
+    hasNext: boolean;
+    nextCursor: string | null;
+    queueRevision: number;
+  }) =>
+    lastPage.hasNext && lastPage.nextCursor
+      ? {
+          cursor: lastPage.nextCursor,
+          queueRevision: lastPage.queueRevision,
+        }
+      : undefined,
+  QUEUE_CONFLICT_CODE: "room.queue-mutation-conflict",
+}));
+
+const page = (entryId: string, hasNext: boolean, revision: number) => ({
+  items: [
+    {
+      order: 1,
+      track: {
+        title: entryId,
+        videoId: entryId,
+        provider: "YOUTUBE" as const,
+        durationMs: 1,
+        thumbnailUrl: null,
+      },
+      status: {
+        skipped: false,
+        isActive: false,
+        isPlayed: false,
+        ownerOrderLocked: false,
+      },
+      addedBy: { slug: "me", nickname: "나", avatarUrl: null },
+      entryId,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    },
+  ],
+  hasNext,
+  nextCursor: hasNext ? entryId : null,
+  queueRevision: revision,
+  totalPendingCount: hasNext ? 2 : 1,
+});
+
+describe("useMyRoomQueue", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("다음 구간 충돌 시 기존 페이지를 비우고 첫 구간부터 다시 조회한다", async () => {
+    vi.mocked(fetchRoomQueuePage)
+      .mockResolvedValueOnce(page("old", true, 10))
+      .mockRejectedValueOnce(
+        new ApiError({
+          status: 409,
+          code: "room.queue-mutation-conflict",
+          message: "conflict",
+        }),
+      )
+      .mockResolvedValueOnce(page("new", false, 11));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useMyRoomQueue("room", null), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextQueuePage();
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.pages[0]?.items[0]?.entryId).toBe("new"),
+    );
+    expect(fetchRoomQueuePage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ cursor: undefined, queueRevision: undefined }),
+    );
+    expect(fetchRoomQueuePage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cursor: "old", queueRevision: 10 }),
+    );
+    expect(fetchRoomQueuePage).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ cursor: undefined, queueRevision: undefined }),
+    );
+    expect(result.current.data?.pages).toHaveLength(1);
+  });
+});

--- a/src/features/playlist/model/useMyRoomQueue.ts
+++ b/src/features/playlist/model/useMyRoomQueue.ts
@@ -1,9 +1,14 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import type { ApiError } from "@/src/shared/api/api-error";
-import { fetchRoomQueue } from "../api/fetchRoomQueue";
-import type { RoomQueueResult } from "./types";
+import { useEffect, useMemo } from "react";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError as ApiErrorValue } from "@/src/shared/api/api-error";
+import {
+  fetchRoomQueuePage,
+  getNextRoomQueuePageParam,
+  QUEUE_CONFLICT_CODE,
+} from "../api/fetchRoomQueue";
+import type { RoomQueuePageParam } from "./types";
 import { playlistKeys } from "./queryKeys";
 
 export function useMyRoomQueue(
@@ -11,9 +16,45 @@ export function useMyRoomQueue(
   password?: string | null,
   enabled = true,
 ) {
-  return useQuery<RoomQueueResult, ApiError>({
-    queryKey: playlistKeys.roomQueue(slug, password, true),
-    queryFn: () => fetchRoomQueue({ slug, password, mine: true }),
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(
+    () => playlistKeys.roomQueue(slug, password, true),
+    [password, slug],
+  );
+  const query = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) =>
+      fetchRoomQueuePage({
+        slug,
+        password,
+        cursor: pageParam?.cursor,
+        queueRevision: pageParam?.queueRevision,
+        mine: true,
+      }),
+    initialPageParam: null as RoomQueuePageParam | null,
+    getNextPageParam: getNextRoomQueuePageParam,
     enabled,
   });
+
+  useEffect(() => {
+    if (
+      !query.isFetchNextPageError &&
+      query.error instanceof ApiErrorValue &&
+      query.error.code === QUEUE_CONFLICT_CODE
+    ) {
+      void queryClient.resetQueries({ queryKey, exact: true });
+    }
+  }, [query.error, query.isFetchNextPageError, queryClient, queryKey]);
+
+  return {
+    ...query,
+    fetchNextQueuePage: async () => {
+      const result = await query.fetchNextPage();
+      const error = result.error;
+      if (error instanceof ApiErrorValue && error.code === QUEUE_CONFLICT_CODE) {
+        await queryClient.resetQueries({ queryKey, exact: true });
+      }
+      return result;
+    },
+  };
 }

--- a/src/features/playlist/model/useRoomQueue.ts
+++ b/src/features/playlist/model/useRoomQueue.ts
@@ -1,22 +1,61 @@
 "use client";
 
-import { useSuspenseQuery } from "@tanstack/react-query";
-import type { ApiError } from "@/src/shared/api/api-error";
-import { fetchRoomQueue } from "../api/fetchRoomQueue";
-import type { RoomQueueResult } from "./types";
+import { useEffect, useMemo } from "react";
+import {
+  useQueryClient,
+  useSuspenseInfiniteQuery,
+} from "@tanstack/react-query";
+import { ApiError as ApiErrorValue } from "@/src/shared/api/api-error";
+import {
+  fetchRoomQueuePage,
+  getNextRoomQueuePageParam,
+  QUEUE_CONFLICT_CODE,
+} from "../api/fetchRoomQueue";
+import type { RoomQueuePageParam } from "./types";
 import { playlistKeys } from "./queryKeys";
 
 export function useRoomQueue(
   slug: string,
   password?: string | null,
 ) {
-  return useSuspenseQuery<RoomQueueResult, ApiError>({
-    queryKey: playlistKeys.roomQueue(slug, password, false),
-    queryFn: () =>
-      fetchRoomQueue({
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(
+    () => playlistKeys.roomQueue(slug, password, false),
+    [password, slug],
+  );
+  const query = useSuspenseInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) =>
+      fetchRoomQueuePage({
         slug,
         password,
+        cursor: pageParam?.cursor,
+        queueRevision: pageParam?.queueRevision,
         mine: false,
       }),
+    initialPageParam: null as RoomQueuePageParam | null,
+    getNextPageParam: getNextRoomQueuePageParam,
   });
+
+  useEffect(() => {
+    if (
+      !query.isFetchNextPageError &&
+      query.error instanceof ApiErrorValue &&
+      query.error.code === QUEUE_CONFLICT_CODE
+    ) {
+      void queryClient.resetQueries({ queryKey, exact: true });
+    }
+  }, [query.error, query.isFetchNextPageError, queryClient, queryKey]);
+
+  return {
+    ...query,
+    fetchNextQueuePage: async () => {
+      const result = await query.fetchNextPage();
+      const error = result.error;
+      if (error instanceof ApiErrorValue && error.code === QUEUE_CONFLICT_CODE) {
+        await queryClient.resetQueries({ queryKey, exact: true });
+      }
+      return result;
+    },
+  };
 }

--- a/src/features/room/api/fetchRooms.test.ts
+++ b/src/features/room/api/fetchRooms.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { axiosInstance } from "@/src/shared/api/axiosInstance";
+import { fetchRooms } from "./fetchRooms";
+
+vi.mock("@/src/shared/api/axiosInstance", () => ({
+  axiosInstance: { get: vi.fn() },
+}));
+
+describe("fetchRooms v26.8 cursor", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("대응하는 cursor 필드만 보내고 legacy lastId는 보내지 않는다", async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValue({
+      data: { result: { rooms: [], hasNext: false } },
+    });
+
+    await fetchRooms({
+      cursorSeed: 7,
+      cursorLastId: 9,
+      cursorLastCreatedAt: "2026-08-02T00:00:00Z",
+      cursorLastRandomRank: 0.5,
+      cursorLastParticipantCount: 3,
+      size: 30,
+      ...({ lastId: 99 } as Record<string, number>),
+    });
+
+    expect(axiosInstance.get).toHaveBeenCalledWith("/api/v1/rooms", {
+      params: {
+        cursorSeed: 7,
+        cursorLastId: 9,
+        cursorLastCreatedAt: "2026-08-02T00:00:00Z",
+        cursorLastRandomRank: 0.5,
+        cursorLastParticipantCount: 3,
+        size: 30,
+      },
+    });
+  });
+});

--- a/src/features/room/api/fetchRooms.ts
+++ b/src/features/room/api/fetchRooms.ts
@@ -20,7 +20,6 @@ export type FetchRoomsParams = {
   cursorLastRandomRank?: number | null;
   cursorSeed?: number | string | null;
   keyword?: string;
-  lastId?: number | null;
   participantOrder?: RoomParticipantOrder;
   size?: number;
 };
@@ -41,7 +40,6 @@ export async function fetchRooms({
   cursorLastRandomRank,
   cursorSeed,
   keyword,
-  lastId,
   participantOrder,
   size,
 }: FetchRoomsParams = {}): Promise<RoomsResponse> {
@@ -57,7 +55,6 @@ export async function fetchRooms({
         ...(trimmedKeyword ? { keyword: trimmedKeyword } : {}),
         ...(createdOrder ? { createdOrder } : {}),
         ...(participantOrder ? { participantOrder } : {}),
-        ...(typeof lastId === "number" ? { lastId } : {}),
         ...(isPresentQueryValue(normalizedCursorSeed)
           ? { cursorSeed: normalizedCursorSeed }
           : {}),

--- a/src/features/room/api/uploadTemporaryRoomThumbnail.test.ts
+++ b/src/features/room/api/uploadTemporaryRoomThumbnail.test.ts
@@ -12,6 +12,12 @@ it("선택한 파일을 방 생성 전 임시 썸네일 API에 업로드한다",
   const uploadResult = {
     uploadToken: "rtu_test",
     thumbnailUrl: "https://example.com/thumbnail.png",
+    thumbnailUrls: null,
+    contentType: "image/png",
+    sizeBytes: 9,
+    width: 100,
+    height: 100,
+    expiresAt: "2026-08-02T08:00:00Z",
   };
   vi.mocked(axiosInstance.post).mockResolvedValue({
     data: { result: uploadResult },
@@ -27,7 +33,7 @@ it("선택한 파일을 방 생성 전 임시 썸네일 API에 업로드한다",
   expect(result).toEqual(uploadResult);
 });
 
-it("성공 응답에 uploadToken이 없으면 계약 오류로 처리한다", async () => {
+it("성공 응답에 필수 메타데이터가 없으면 계약 오류로 처리한다", async () => {
   const file = new File(["thumbnail"], "cover.png", { type: "image/png" });
   vi.mocked(axiosInstance.post).mockResolvedValue({
     data: {

--- a/src/features/room/api/uploadTemporaryRoomThumbnail.ts
+++ b/src/features/room/api/uploadTemporaryRoomThumbnail.ts
@@ -9,18 +9,55 @@ export type UploadTemporaryRoomThumbnailParams = {
 };
 
 export type UploadTemporaryRoomThumbnailResult = {
-  width?: number;
-  height?: number;
-  expiresAt?: string;
-  sizeBytes?: number;
-  contentType?: string;
   uploadToken: string;
   thumbnailUrl: string;
-  thumbnailUrls?: ThumbnailUrls;
+  thumbnailUrls: ThumbnailUrls | null;
+  contentType: string;
+  sizeBytes: number;
+  width: number;
+  height: number;
+  expiresAt: string;
 };
 
 type UploadTemporaryRoomThumbnailResponse =
   ApiResponse<UploadTemporaryRoomThumbnailResult>;
+
+function isThumbnailUrls(value: unknown): value is ThumbnailUrls {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<ThumbnailUrls>;
+  return (
+    typeof candidate.thumb256 === "string" &&
+    typeof candidate.thumb384 === "string" &&
+    typeof candidate.thumb640 === "string" &&
+    typeof candidate.thumb828 === "string" &&
+    typeof candidate.thumb1200 === "string"
+  );
+}
+
+function isUploadResult(
+  value: unknown,
+): value is UploadTemporaryRoomThumbnailResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<UploadTemporaryRoomThumbnailResult>;
+  return (
+    typeof candidate.uploadToken === "string" &&
+    Boolean(candidate.uploadToken) &&
+    typeof candidate.thumbnailUrl === "string" &&
+    (candidate.thumbnailUrls === null ||
+      isThumbnailUrls(candidate.thumbnailUrls)) &&
+    typeof candidate.contentType === "string" &&
+    typeof candidate.sizeBytes === "number" &&
+    typeof candidate.width === "number" &&
+    typeof candidate.height === "number" &&
+    typeof candidate.expiresAt === "string"
+  );
+}
 
 export async function uploadTemporaryRoomThumbnail({
   file,
@@ -36,7 +73,7 @@ export async function uploadTemporaryRoomThumbnail({
 
   const result = unwrapApiResponse(response.data);
 
-  if (!result.uploadToken) {
+  if (!isUploadResult(result)) {
     throw new ApiError({
       message: "썸네일 업로드 응답이 올바르지 않습니다.",
       status: 500,

--- a/src/features/room/api/websocket/subscribeUserJoinEvents.test.ts
+++ b/src/features/room/api/websocket/subscribeUserJoinEvents.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseRoomJoinEvent } from "./subscribeUserJoinEvents";
+
+describe("parseRoomJoinEvent", () => {
+  it("필수 roomSlug와 timestamp가 있는 join 사건만 허용한다", () => {
+    expect(
+      parseRoomJoinEvent(
+        JSON.stringify({
+          type: "ROOM_JOINED",
+          roomSlug: "room",
+          timestamp: 1,
+          data: null,
+        }),
+      ),
+    ).toMatchObject({ roomSlug: "room", timestamp: 1 });
+    expect(
+      parseRoomJoinEvent(
+        JSON.stringify({ type: "ROOM_JOINED", timestamp: 1, data: null }),
+      ),
+    ).toBeNull();
+    expect(
+      parseRoomJoinEvent(
+        JSON.stringify({ type: "ROOM_JOINED", roomSlug: "room", data: null }),
+      ),
+    ).toBeNull();
+    expect(
+      parseRoomJoinEvent(
+        JSON.stringify({
+          type: "ROOM_JOINED",
+          roomSlug: "room",
+          timestamp: 1,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseRoomJoinEvent(
+        JSON.stringify({
+          type: "ROOM_JOIN_FAILED",
+          roomSlug: "room",
+          timestamp: 1,
+          data: null,
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/features/room/api/websocket/subscribeUserJoinEvents.ts
+++ b/src/features/room/api/websocket/subscribeUserJoinEvents.ts
@@ -1,14 +1,15 @@
 import type { StompSubscription } from "@stomp/stompjs";
 import { ApiError } from "@/src/shared/api/api-error";
-import type {
-  RoomJoinedData,
-  WsErrorData,
-  WsEvent,
-} from "@/src/features/room/model/types";
+import type { RoomJoinedData, WsErrorData } from "@/src/features/room/model/types";
 import type { JoinRoomResult } from "../joinRoom.types";
 import { getSocketClient } from "@/src/shared/api/websocket/stompConnection";
 
-type RoomJoinEvent = Partial<WsEvent>;
+export type RoomJoinEvent = {
+  type: "ROOM_JOINED" | "ERROR";
+  roomSlug: string;
+  timestamp: number;
+  data: unknown;
+};
 
 export type JoinHandlers = {
   onJoined: (result: JoinRoomResult) => void;
@@ -25,6 +26,50 @@ function getRoomJoinedData(data: unknown): RoomJoinedData | null {
   return data as RoomJoinedData;
 }
 
+function getWsErrorData(data: unknown): WsErrorData | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const candidate = data as Partial<WsErrorData>;
+  if (
+    typeof candidate.statusCode !== "number" ||
+    typeof candidate.code !== "string" ||
+    typeof candidate.message !== "string"
+  ) {
+    return null;
+  }
+
+  return candidate as WsErrorData;
+}
+
+export function parseRoomJoinEvent(body: string): RoomJoinEvent | null {
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(body) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+
+  const event = candidate as Partial<RoomJoinEvent>;
+  if (
+    (event.type !== "ROOM_JOINED" && event.type !== "ERROR") ||
+    typeof event.roomSlug !== "string" ||
+    !event.roomSlug.trim() ||
+    typeof event.timestamp !== "number" ||
+    !Number.isFinite(event.timestamp) ||
+    !("data" in event)
+  ) {
+    return null;
+  }
+
+  return event as RoomJoinEvent;
+}
+
 // 유저 전용 토픽에서 현재 방 join 결과만 골라서 전달한다.
 export function subscribeUserJoinEvents(
   safeSlug: string,
@@ -35,29 +80,25 @@ export function subscribeUserJoinEvents(
   return client.subscribe(USER_EVENTS_DESTINATION, ({ body }) => {
     if (!body) return;
 
-    let event: RoomJoinEvent;
-    try {
-      event = JSON.parse(body) as RoomJoinEvent;
-    } catch {
-      return;
-    }
-
-    const eventRoomSlug = event.roomSlug ?? safeSlug;
-    if (eventRoomSlug !== safeSlug) {
+    const event = parseRoomJoinEvent(body);
+    if (!event || event.roomSlug !== safeSlug) {
       return;
     }
 
     if (event.type === "ROOM_JOINED") {
       handlers.onJoined({
-        roomSlug: eventRoomSlug,
-        timestamp: event.timestamp ?? Date.now(),
+        roomSlug: event.roomSlug,
+        timestamp: event.timestamp,
         data: getRoomJoinedData(event.data),
       });
       return;
     }
 
-    if (event.type === "ERROR" || event.type === "ROOM_JOIN_FAILED") {
-      const errorData = event.data as WsErrorData;
+    if (event.type === "ERROR") {
+      const errorData = getWsErrorData(event.data);
+      if (!errorData) {
+        return;
+      }
       handlers.onError(
         new ApiError({
           status: errorData.statusCode,

--- a/src/features/room/chat/model/chatMessages.test.ts
+++ b/src/features/room/chat/model/chatMessages.test.ts
@@ -19,7 +19,6 @@ function message(overrides: Partial<ChatMessage>): ChatMessage {
     messageId: 1,
     messageKey: "message-key",
     messageType: "TEXT",
-    senderId: 2,
     senderNickname: "대상",
     senderProfileImageUrl: null,
     senderSlug: "target-user",
@@ -32,7 +31,7 @@ describe("getChatMessageManagementActions", () => {
   it("본인 메시지에는 관리 액션을 제공하지 않는다", () => {
     expect(
       getChatMessageManagementActions(
-        message({ senderId: 1, senderNickname: "나", senderSlug: "me" }),
+        message({ senderNickname: "나", senderSlug: "me" }),
         currentUser,
       ),
     ).toEqual([]);
@@ -52,7 +51,7 @@ describe("getChatMessageManagementActions", () => {
   it("비회원 메시지는 messageKey가 있을 때 신고만 제공한다", () => {
     expect(
       getChatMessageManagementActions(
-        message({ senderId: null, senderSlug: null }),
+        message({ senderSlug: null }),
         currentUser,
       ),
     ).toEqual(["report"]);

--- a/src/features/room/chat/model/chatMessages.ts
+++ b/src/features/room/chat/model/chatMessages.ts
@@ -19,12 +19,8 @@ export function isChatMessageData(data: unknown): data is ChatMessageEventData {
     typeof candidate.messageId === "number" ||
     (typeof candidate.messageKey === "string" &&
       candidate.messageKey.trim().length > 0);
-  const hasValidSenderId =
-    candidate.senderId == null || typeof candidate.senderId === "number";
   const hasValidSenderSlug =
     candidate.senderSlug === null || typeof candidate.senderSlug === "string";
-  const hasSenderIdentity =
-    hasValidSenderSlug || typeof candidate.senderId === "number";
 
   return (
     hasValidMessageId &&
@@ -32,8 +28,7 @@ export function isChatMessageData(data: unknown): data is ChatMessageEventData {
     hasStableMessageIdentity &&
     typeof candidate.messageType === "string" &&
     typeof candidate.content === "string" &&
-    hasValidSenderId &&
-    hasSenderIdentity &&
+    hasValidSenderSlug &&
     typeof candidate.senderNickname === "string" &&
     (candidate.senderProfileImageUrl == null ||
       typeof candidate.senderProfileImageUrl === "string") &&
@@ -149,29 +144,7 @@ export function isChatMessageFromUser(
     return false;
   }
 
-  let hasStableIdentity = false;
-
-  if (message.senderSlug && user.slug) {
-    hasStableIdentity = true;
-
-    if (message.senderSlug === user.slug) {
-      return true;
-    }
-  }
-
-  if (message.senderId != null && user.userId != null) {
-    hasStableIdentity = true;
-
-    if (message.senderId === user.userId) {
-      return true;
-    }
-  }
-
-  if (hasStableIdentity) {
-    return false;
-  }
-
-  return message.senderNickname === user.nickname;
+  return Boolean(message.senderSlug && message.senderSlug === user.slug);
 }
 
 export type ChatMessageManagementAction = "block" | "report";

--- a/src/features/room/chat/ui/ChatArea.test.tsx
+++ b/src/features/room/chat/ui/ChatArea.test.tsx
@@ -51,7 +51,6 @@ function message(
     messageId: null,
     messageKey: `${nickname}-key`,
     messageType: "TEXT",
-    senderId: 2,
     senderNickname: nickname,
     senderProfileImageUrl: null,
     senderSlug: `${nickname}-slug`,
@@ -61,11 +60,11 @@ function message(
 }
 
 const messages = [
-  message("본인", { senderId: 1, senderNickname: "나", senderSlug: "me" }),
+  message("본인", { senderNickname: "나", senderSlug: "me" }),
   message("회원", {}),
-  message("비회원", { senderId: null, senderSlug: null }),
+  message("비회원", { senderSlug: null }),
   message("구형", { messageKey: null }),
-  message("식별없음", { messageKey: null, senderId: null, senderSlug: null }),
+  message("식별없음", { messageKey: null, senderSlug: null }),
 ];
 
 function renderChat(chatMessages = messages) {

--- a/src/features/room/create/ui/RoomFormModal.test.tsx
+++ b/src/features/room/create/ui/RoomFormModal.test.tsx
@@ -78,6 +78,19 @@ async function selectThumbnail(fileName = "cover.png") {
   return file;
 }
 
+function uploadResult(uploadToken: string, thumbnailUrl: string) {
+  return {
+    uploadToken,
+    thumbnailUrl,
+    thumbnailUrls: null,
+    contentType: "image/png",
+    sizeBytes: 9,
+    width: 100,
+    height: 100,
+    expiresAt: "2026-08-02T08:00:00Z",
+  };
+}
+
 describe("RoomFormModal room form flows", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -148,10 +161,9 @@ describe("RoomFormModal room form flows", () => {
           status: 400,
         }),
       )
-      .mockResolvedValueOnce({
-        uploadToken: "rtu_retry",
-        thumbnailUrl: "https://example.com/retry.png",
-      });
+      .mockResolvedValueOnce(
+        uploadResult("rtu_retry", "https://example.com/retry.png"),
+      );
     renderCreateRoomModal();
 
     await selectThumbnail("invalid.png");
@@ -172,10 +184,9 @@ describe("RoomFormModal room form flows", () => {
 
   it("성공한 uploadToken을 방 생성 payload에 포함한다", async () => {
     const user = userEvent.setup();
-    vi.mocked(uploadTemporaryRoomThumbnail).mockResolvedValue({
-      uploadToken: "rtu_success",
-      thumbnailUrl: "https://example.com/success.png",
-    });
+    vi.mocked(uploadTemporaryRoomThumbnail).mockResolvedValue(
+      uploadResult("rtu_success", "https://example.com/success.png"),
+    );
     vi.mocked(createRoom).mockResolvedValue({ slug: "created-room" });
     renderCreateRoomModal();
 
@@ -201,10 +212,9 @@ describe("RoomFormModal room form flows", () => {
 
   it("업로드 성공 후 선택을 제거하면 token도 생성 payload에서 제외한다", async () => {
     const user = userEvent.setup();
-    vi.mocked(uploadTemporaryRoomThumbnail).mockResolvedValue({
-      uploadToken: "rtu_removed",
-      thumbnailUrl: "https://example.com/removed.png",
-    });
+    vi.mocked(uploadTemporaryRoomThumbnail).mockResolvedValue(
+      uploadResult("rtu_removed", "https://example.com/removed.png"),
+    );
     vi.mocked(createRoom).mockResolvedValue({ slug: "room-after-clear" });
     renderCreateRoomModal();
 

--- a/src/features/room/hooks/useFetchRooms.ts
+++ b/src/features/room/hooks/useFetchRooms.ts
@@ -23,11 +23,6 @@ export type RoomsQueryParams = Partial<RoomListQueryParams>;
 
 type RoomsPageParam =
   | {
-      type: "legacy";
-      lastId: number;
-    }
-  | {
-      type: "cursor";
       cursorLastCreatedAt?: string;
       cursorLastId?: number;
       cursorLastParticipantCount?: number;
@@ -67,10 +62,6 @@ export function normalizeRoomsQueryParams(
   };
 }
 
-function isLegacyPaginationMode(params: RoomListQueryParams) {
-  return params.createdOrder === "NEW" && params.participantOrder === "RANDOM";
-}
-
 function hasCursorValue(value: unknown): value is number | string {
   if (typeof value === "number") {
     return Number.isFinite(value);
@@ -81,7 +72,6 @@ function hasCursorValue(value: unknown): value is number | string {
 
 function getCursorPageParam(lastPage: RoomsResponse): RoomsPageParam {
   const cursorPageParam = {
-    type: "cursor" as const,
     ...(hasCursorValue(lastPage.nextCursorSeed)
       ? { cursorSeed: lastPage.nextCursorSeed }
       : {}),
@@ -99,25 +89,16 @@ function getCursorPageParam(lastPage: RoomsResponse): RoomsPageParam {
       : {}),
   };
 
-  return Object.keys(cursorPageParam).length > 1
+  return Object.keys(cursorPageParam).length > 0
     ? cursorPageParam
     : undefined;
 }
 
 function getNextRoomsPageParam(
   lastPage: RoomsResponse,
-  params: RoomListQueryParams,
 ): RoomsPageParam {
   if (!lastPage.hasNext) {
     return undefined;
-  }
-
-  if (isLegacyPaginationMode(params)) {
-    const lastRoomId = lastPage.rooms.at(-1)?.id;
-
-    return typeof lastRoomId === "number"
-      ? { type: "legacy", lastId: lastRoomId }
-      : undefined;
   }
 
   return getCursorPageParam(lastPage);
@@ -126,12 +107,6 @@ function getNextRoomsPageParam(
 function getPageFetchParams(pageParam: RoomsPageParam): FetchRoomsParams {
   if (!pageParam) {
     return {};
-  }
-
-  if (pageParam.type === "legacy") {
-    return {
-      lastId: pageParam.lastId,
-    };
   }
 
   return {
@@ -163,6 +138,6 @@ export function useRoomsQuery(params: RoomsQueryParams = {}) {
       }),
     initialPageParam: undefined,
     getNextPageParam: (lastPage) =>
-      getNextRoomsPageParam(lastPage, normalizedParams),
+      getNextRoomsPageParam(lastPage),
   });
 }

--- a/src/features/room/join/model/roomJoinErrors.test.ts
+++ b/src/features/room/join/model/roomJoinErrors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/src/shared/api/api-error";
+import {
+  isRoomAccessDeniedError,
+  shouldKeepPasswordFormAfterSubmit,
+} from "./roomJoinErrors";
+
+describe("roomJoinErrors", () => {
+  it("room.access-denied만 비공개 방 접근 오류로 취급한다", () => {
+    const accessDenied = new ApiError({
+      status: 400,
+      code: "room.access-denied",
+      message: "방에 접근할 수 없어요. 방 주소 또는 비밀번호를 확인해 주세요.",
+    });
+    expect(isRoomAccessDeniedError(accessDenied)).toBe(true);
+    expect(shouldKeepPasswordFormAfterSubmit(accessDenied)).toBe(true);
+    expect(
+      isRoomAccessDeniedError(
+        new ApiError({
+          status: 400,
+          code: "room.password-required",
+          message: "비밀번호가 필요합니다.",
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/features/room/join/model/roomJoinErrors.ts
+++ b/src/features/room/join/model/roomJoinErrors.ts
@@ -1,19 +1,14 @@
 import { ApiError } from "@/src/shared/api/api-error";
 
-export function isPasswordRequiredError(error: unknown) {
+export function isRoomAccessDeniedError(error: unknown) {
   return (
     error instanceof ApiError &&
-    (error.code === "room.password-required" ||
-      error.code === "room.invalid-password" ||
-      error.code === "room.password-invalid" ||
-      error.message.includes("비밀번호"))
+    error.code === "room.access-denied"
   );
 }
 
 export function shouldKeepPasswordFormAfterSubmit(error: ApiError) {
   return (
-    isPasswordRequiredError(error) ||
-    error.status === 400 ||
-    error.status === 403
+    isRoomAccessDeniedError(error)
   );
 }

--- a/src/features/room/lib/getDefaultRoomImage.ts
+++ b/src/features/room/lib/getDefaultRoomImage.ts
@@ -21,8 +21,6 @@ export const ROOM_CARD_IMAGE_VARIANTS = [
   "thumb256",
   "thumb384",
   "thumb640",
-  "small",
-  "medium",
 ] as const;
 
 export const ROOM_STAGE_IMAGE_VARIANTS = [
@@ -30,16 +28,12 @@ export const ROOM_STAGE_IMAGE_VARIANTS = [
   "thumb1200",
   "thumb640",
   "thumb384",
-  "large",
-  "medium",
 ] as const;
 
 export const ROOM_HERO_IMAGE_VARIANTS = [
   "thumb1200",
   "thumb828",
   "thumb640",
-  "large",
-  "medium",
 ] as const;
 
 const DEFAULT_ROOM_IMAGE_VARIANTS = [
@@ -48,15 +42,11 @@ const DEFAULT_ROOM_IMAGE_VARIANTS = [
   "thumb384",
   "thumb1200",
   "thumb256",
-  "medium",
-  "large",
-  "small",
-  "original",
 ] as const;
 
 type GetRoomImageSrcParams = {
   fallbackSeed: number;
-  preferredVariants?: readonly string[];
+  preferredVariants?: readonly (keyof ThumbnailUrls)[];
   thumbnailUrl?: string | null;
   thumbnailUrls?: ThumbnailUrls | null;
 };
@@ -69,7 +59,7 @@ function normalizeImageUrl(imageUrl: string | null | undefined) {
 
 function getRoomThumbnailVariantUrl(
   thumbnailUrls: ThumbnailUrls | null | undefined,
-  preferredVariants: readonly string[],
+  preferredVariants: readonly (keyof ThumbnailUrls)[],
 ) {
   if (!thumbnailUrls) {
     return null;

--- a/src/features/room/lib/isRoomOwner.ts
+++ b/src/features/room/lib/isRoomOwner.ts
@@ -1,11 +1,9 @@
 type UserLike = {
   slug?: string | null;
-  userSlug?: string | null;
-  userId?: number | null;
 };
 
 function getPublicUserSlug(user: UserLike | null | undefined) {
-  const slug = user?.userSlug ?? user?.slug;
+  const slug = user?.slug;
 
   return slug?.trim() || null;
 }
@@ -20,15 +18,7 @@ export function isSameUser(
 
   const leftSlug = getPublicUserSlug(left);
   const rightSlug = getPublicUserSlug(right);
-  if (leftSlug && rightSlug) {
-    return leftSlug === rightSlug;
-  }
-
-  if (left.userId != null && right.userId != null) {
-    return left.userId === right.userId;
-  }
-
-  return false;
+  return Boolean(leftSlug && rightSlug && leftSlug === rightSlug);
 }
 
 export function isRoomOwner(

--- a/src/features/room/model/types.ts
+++ b/src/features/room/model/types.ts
@@ -29,23 +29,17 @@ export type RoomMeta = {
 };
 
 export type ThumbnailUrls = {
-  thumb256?: string | null;
-  thumb384?: string | null;
-  thumb640?: string | null;
-  thumb828?: string | null;
-  thumb1200?: string | null;
-  original?: string | null;
-  small?: string | null;
-  medium?: string | null;
-  large?: string | null;
-  [key: string]: string | null | undefined;
+  thumb256: string;
+  thumb384: string;
+  thumb640: string;
+  thumb828: string;
+  thumb1200: string;
 };
 
 export type RoomOwner = {
   slug: string;
-  userId?: number | null;
   nickname: string;
-  profileImageUrl?: string | null;
+  profileImageUrl: string | null;
 };
 
 export type RoomsResponse = {
@@ -87,8 +81,6 @@ export type ChatMessage = {
   messageType: "TEXT" | string;
   content: string;
   senderSlug: string | null;
-  // Legacy compatibility: current public chat contract uses senderSlug.
-  senderId?: number | null;
   senderNickname: string;
   senderProfileImageUrl: string | null;
   sentAt: number;
@@ -102,13 +94,11 @@ export type ChatHistoryResponse = {
 
 export type RoomJoinedData = {
   participant: {
-    participantType?: "USER" | "GUEST" | (string & {});
-    participantId?: string | null;
-    userSlug?: string | null;
-    slug?: string | null;
-    userId?: number | null;
+    participantType: "USER" | "GUEST";
+    participantId: string;
+    userSlug: string | null;
     nickname: string;
-    profileImageUrl?: string | null;
+    profileImageUrl: string | null;
   };
   recentChatMessages: ChatMessage[];
 };

--- a/src/features/room/page/hooks/useRoomPlaybackViewModel.ts
+++ b/src/features/room/page/hooks/useRoomPlaybackViewModel.ts
@@ -82,15 +82,7 @@ function getCurrentRequesterProfile(
   const requesterSlug = requester.slug?.trim() || null;
   const matchedParticipant = participants.find((participant) => {
     const participantSlug = getParticipantUserSlug(participant);
-    if (requesterSlug && participantSlug) {
-      return participantSlug === requesterSlug;
-    }
-
-    if (typeof requester.userId === "number") {
-      return participant.userId === requester.userId;
-    }
-
-    return participant.nickname === requester.nickname;
+    return Boolean(requesterSlug && participantSlug === requesterSlug);
   });
   const matchedParticipantSlug = getParticipantUserSlug(matchedParticipant);
 
@@ -98,7 +90,6 @@ function getCurrentRequesterProfile(
     avatarUrl: requester.avatarUrl ?? matchedParticipant?.profileImageUrl ?? null,
     nickname: requester.nickname,
     slug: requesterSlug ?? matchedParticipantSlug,
-    userId: requester.userId ?? matchedParticipant?.userId ?? null,
   };
 }
 

--- a/src/features/room/page/hooks/useRoomRealtimeEvents.test.tsx
+++ b/src/features/room/page/hooks/useRoomRealtimeEvents.test.tsx
@@ -5,7 +5,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { joinRoom } from "@/src/features/room/api/joinRoom";
 import { publishLeaveRequest } from "@/src/features/room/api/websocket/publishLeaveRequest";
 import { subscribeRoomEvents } from "@/src/features/room/api/websocket/subscribeRoomEvents";
-import { addSocketListener } from "@/src/shared/api/websocket/stompConnection";
+import {
+  addSocketListener,
+  getSocketClient,
+  stopSocketAutoReconnect,
+} from "@/src/shared/api/websocket/stompConnection";
 import { useRoomRealtimeEvents } from "./useRoomRealtimeEvents";
 
 vi.mock("next/navigation", () => ({
@@ -25,11 +29,95 @@ vi.mock(
 );
 vi.mock("@/src/shared/api/websocket/stompConnection", () => ({
   addSocketListener: vi.fn(),
+  getSocketClient: vi.fn(),
+  stopSocketAutoReconnect: vi.fn(),
 }));
 
 describe("useRoomRealtimeEvents 재연결", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getSocketClient).mockReturnValue({
+      subscribe: vi.fn(() => ({ id: "user-events", unsubscribe: vi.fn() })),
+    } as never);
+  });
+
+  it("같은 방 session-replaced를 받으면 방 연결만 정리하고 재접속을 중단한다", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    let userEventHandler: ((message: { body: string }) => void) | undefined;
+    const userSubscription = { id: "user-events", unsubscribe: vi.fn() };
+    vi.mocked(getSocketClient).mockReturnValue({
+      subscribe: vi.fn((_destination, handler) => {
+        userEventHandler = handler as typeof userEventHandler;
+        return userSubscription;
+      }),
+    } as never);
+    vi.mocked(addSocketListener).mockReturnValue(vi.fn());
+    const roomSubscription = { id: "room-events", unsubscribe: vi.fn() };
+    vi.mocked(subscribeRoomEvents).mockReturnValue(roomSubscription);
+    const setJoinErrorMessage = vi.fn();
+    const setStatus = vi.fn();
+    const resetChatState = vi.fn();
+    const cleanupChatSubscriptions = vi.fn();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () =>
+        useRoomRealtimeEvents({
+          cleanupChatSubscriptions,
+          initializeChatStateFromJoinData: vi.fn(),
+          resetChatState,
+          setJoinErrorMessage,
+          setLivePlaybackStatus: vi.fn(),
+          setStatus,
+          slug: "room",
+        }),
+      { wrapper },
+    );
+
+    act(() => result.current.ensureRoomSubscription("room", null));
+    act(() => {
+      userEventHandler?.({
+        body: JSON.stringify({
+          type: "ERROR",
+          roomSlug: "other-room",
+          timestamp: 1,
+          data: {
+            code: "user.session-replaced",
+            message: "server message",
+          },
+        }),
+      });
+    });
+    expect(stopSocketAutoReconnect).not.toHaveBeenCalled();
+    expect(roomSubscription.unsubscribe).not.toHaveBeenCalled();
+
+    act(() => {
+      userEventHandler?.({
+        body: JSON.stringify({
+          type: "ERROR",
+          roomSlug: "room",
+          timestamp: 1,
+          data: {
+            code: "user.session-replaced",
+            message: "server message",
+          },
+        }),
+      });
+    });
+
+    expect(roomSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(userSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(cleanupChatSubscriptions).toHaveBeenCalledTimes(1);
+    expect(resetChatState).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith("error");
+    expect(setJoinErrorMessage).toHaveBeenCalledWith(
+      "현재 방은 다른 창에서 마지막으로 열렸습니다.",
+    );
+    expect(stopSocketAutoReconnect).toHaveBeenCalledTimes(1);
+    expect(publishLeaveRequest).not.toHaveBeenCalled();
   });
 
   it("연결 종료 후 join부터 복구하고 중복 없이 다시 구독한다", async () => {

--- a/src/features/room/page/hooks/useRoomRealtimeEvents.ts
+++ b/src/features/room/page/hooks/useRoomRealtimeEvents.ts
@@ -33,11 +33,16 @@ import {
 } from "@/src/features/room/api/joinRoom";
 import { publishLeaveRequest } from "@/src/features/room/api/websocket/publishLeaveRequest";
 import {
-  isPasswordRequiredError,
+  isRoomAccessDeniedError,
   shouldKeepPasswordFormAfterSubmit,
 } from "@/src/features/room/join/model/roomJoinErrors";
 import { ApiError } from "@/src/shared/api/api-error";
-import { addSocketListener } from "@/src/shared/api/websocket/stompConnection";
+import {
+  addSocketListener,
+  getSocketClient,
+  stopSocketAutoReconnect,
+} from "@/src/shared/api/websocket/stompConnection";
+import { parseRoomJoinEvent } from "@/src/features/room/api/websocket/subscribeUserJoinEvents";
 import { normalizeRoomSlug } from "@/src/shared/lib/normalizeRoomSlug";
 import {
   applyMusicPowerChange,
@@ -52,6 +57,9 @@ import type { LivePlaybackState } from "./useRoomPlaybackViewModel";
 type JoinStatus = "joining" | "joined" | "error" | "needs-password";
 
 const PARTICIPANT_KICKED_ERROR_CODE = "room.participant-kicked";
+const SESSION_REPLACED_ERROR_CODE = "user.session-replaced";
+const SESSION_REPLACED_MESSAGE =
+  "현재 방은 다른 창에서 마지막으로 열렸습니다.";
 
 function isPlaybackSyncData(data: unknown): data is PlaybackSyncData {
   if (!data || typeof data !== "object") {
@@ -80,6 +88,20 @@ function isWsErrorData(data: unknown): data is WsErrorData {
   return (
     typeof candidate.statusCode === "number" &&
     typeof candidate.code === "string" &&
+    typeof candidate.message === "string"
+  );
+}
+
+function isSessionReplacedData(
+  data: unknown,
+): data is { code: string; message: string } {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const candidate = data as { code?: unknown; message?: unknown };
+  return (
+    candidate.code === SESSION_REPLACED_ERROR_CODE &&
     typeof candidate.message === "string"
   );
 }
@@ -113,6 +135,7 @@ export function useRoomRealtimeEvents({
   const queryClient = useQueryClient();
   const router = useRouter();
   const roomSubscriptionRef = useRef<StompSubscription | null>(null);
+  const userSubscriptionRef = useRef<StompSubscription | null>(null);
   const roomSubscriptionConfigRef = useRef<RoomSubscriptionConfig | null>(null);
   const reconnectPendingRef = useRef(false);
   const rejoinAbortControllerRef = useRef<AbortController | null>(null);
@@ -127,6 +150,15 @@ export function useRoomRealtimeEvents({
     roomSubscriptionRef.current = null;
   }, []);
 
+  const cleanupUserSubscription = useCallback(() => {
+    try {
+      userSubscriptionRef.current?.unsubscribe();
+    } catch {
+      // The socket may already be closing or reconnecting.
+    }
+    userSubscriptionRef.current = null;
+  }, []);
+
   const cancelRejoin = useCallback(() => {
     rejoinAbortControllerRef.current?.abort();
     rejoinAbortControllerRef.current = null;
@@ -135,21 +167,23 @@ export function useRoomRealtimeEvents({
   const cleanupRoomSubscription = useCallback(() => {
     cancelRejoin();
     cleanupBrokerSubscription();
+    cleanupUserSubscription();
     roomSubscriptionConfigRef.current = null;
     reconnectPendingRef.current = false;
-  }, [cancelRejoin, cleanupBrokerSubscription]);
+  }, [cancelRejoin, cleanupBrokerSubscription, cleanupUserSubscription]);
 
   const leaveRoomSession = useCallback(() => {
     const config = roomSubscriptionConfigRef.current;
     cancelRejoin();
     cleanupBrokerSubscription();
+    cleanupUserSubscription();
     roomSubscriptionConfigRef.current = null;
     reconnectPendingRef.current = false;
 
     if (config) {
       publishLeaveRequest(config.slug);
     }
-  }, [cancelRejoin, cleanupBrokerSubscription]);
+  }, [cancelRejoin, cleanupBrokerSubscription, cleanupUserSubscription]);
 
   const invalidateRoomReads = useCallback(
     (roomSlug: string) => {
@@ -299,6 +333,74 @@ export function useRoomRealtimeEvents({
     [cleanupBrokerSubscription, handleRoomEvent],
   );
 
+  const handleSessionReplaced = useCallback(
+    (roomSlug: string) => {
+      const config = roomSubscriptionConfigRef.current;
+      if (!config || config.slug !== roomSlug) {
+        return;
+      }
+
+      cancelRejoin();
+      cleanupBrokerSubscription();
+      cleanupUserSubscription();
+      roomSubscriptionConfigRef.current = null;
+      reconnectPendingRef.current = false;
+      cleanupChatSubscriptions();
+      resetChatState();
+      setLivePlaybackStatus(null);
+      setJoinErrorMessage(SESSION_REPLACED_MESSAGE);
+      setStatus("error");
+      void queryClient.removeQueries({
+        queryKey: playlistKeys.roomPlaybackPrefix(roomSlug),
+      });
+      void queryClient.removeQueries({
+        queryKey: playlistKeys.roomParticipantsPrefix(roomSlug),
+      });
+      void queryClient.removeQueries({
+        queryKey: playlistKeys.roomQueuePrefix(roomSlug),
+      });
+      stopSocketAutoReconnect();
+    },
+    [
+      cancelRejoin,
+      cleanupBrokerSubscription,
+      cleanupChatSubscriptions,
+      cleanupUserSubscription,
+      queryClient,
+      resetChatState,
+      setJoinErrorMessage,
+      setLivePlaybackStatus,
+      setStatus,
+    ],
+  );
+
+  const subscribeUserEvents = useCallback(
+    (config: RoomSubscriptionConfig) => {
+      cleanupUserSubscription();
+      userSubscriptionRef.current = getSocketClient().subscribe(
+        "/user/playlist/events",
+        ({ body }) => {
+          if (!body) {
+            return;
+          }
+
+          const event = parseRoomJoinEvent(body);
+          if (
+            !event ||
+            event.roomSlug !== config.slug ||
+            event.type !== "ERROR" ||
+            !isSessionReplacedData(event.data)
+          ) {
+            return;
+          }
+
+          handleSessionReplaced(config.slug);
+        },
+      );
+    },
+    [cleanupUserSubscription, handleSessionReplaced],
+  );
+
   useEffect(() => {
     hasRedirectedAfterKickRef.current = false;
   }, [slug]);
@@ -338,6 +440,7 @@ export function useRoomRealtimeEvents({
 
             initializeChatStateFromJoinData(joinResult.data);
             subscribeWithConfig(config, true);
+            subscribeUserEvents(config);
             invalidateRoomReads(config.slug);
             setJoinErrorMessage("");
             setStatus("joined");
@@ -359,7 +462,7 @@ export function useRoomRealtimeEvents({
                     message: "방 연결을 복구하지 못했습니다.",
                   });
             const shouldRequestPassword =
-              isPasswordRequiredError(joinError) ||
+              isRoomAccessDeniedError(joinError) ||
               (config.password !== null &&
                 shouldKeepPasswordFormAfterSubmit(joinError));
 
@@ -384,6 +487,7 @@ export function useRoomRealtimeEvents({
 
         cancelRejoin();
         cleanupBrokerSubscription();
+        cleanupUserSubscription();
         cleanupChatSubscriptions();
         reconnectPendingRef.current = true;
         setJoinErrorMessage("");
@@ -433,6 +537,7 @@ export function useRoomRealtimeEvents({
     cleanupRoomSubscription,
     cancelRejoin,
     cleanupBrokerSubscription,
+    cleanupUserSubscription,
     initializeChatStateFromJoinData,
     invalidateRoomReads,
     queryClient,
@@ -442,6 +547,7 @@ export function useRoomRealtimeEvents({
     setStatus,
     slug,
     subscribeWithConfig,
+    subscribeUserEvents,
   ]);
 
   const ensureRoomSubscription = useCallback(
@@ -461,8 +567,9 @@ export function useRoomRealtimeEvents({
 
       roomSubscriptionConfigRef.current = config;
       subscribeWithConfig(config, true);
+      subscribeUserEvents(config);
     },
-    [subscribeWithConfig],
+    [subscribeUserEvents, subscribeWithConfig],
   );
 
   return {

--- a/src/features/room/page/model/roomRealtimeEvents.test.ts
+++ b/src/features/room/page/model/roomRealtimeEvents.test.ts
@@ -62,4 +62,13 @@ describe("방 실시간 이벤트 guard와 캐시 변환", () => {
   it("필수 필드가 빠진 이벤트를 거부한다", () => {
     expect(isTrackStartedData({ ...trackStarted, addedBy: {} })).toBe(false);
   });
+
+  it("TRACK_STARTED의 null 썸네일을 허용한다", () => {
+    expect(
+      isTrackStartedData({
+        ...trackStarted,
+        track: { ...trackStarted.track, thumbnailUrl: null },
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/features/room/page/model/roomRealtimeEvents.ts
+++ b/src/features/room/page/model/roomRealtimeEvents.ts
@@ -93,14 +93,10 @@ export function isTrackStartedData(value: unknown): value is TrackStartedData {
     typeof track.videoId === "string" &&
     typeof track.provider === "string" &&
     typeof track.durationMs === "number" &&
-    typeof track.thumbnailUrl === "string" &&
+    (track.thumbnailUrl === null || typeof track.thumbnailUrl === "string") &&
     typeof addedBy.nickname === "string" &&
-    (addedBy.slug === undefined ||
-      addedBy.slug === null ||
-      typeof addedBy.slug === "string") &&
-    (addedBy.avatarUrl === undefined ||
-      addedBy.avatarUrl === null ||
-      typeof addedBy.avatarUrl === "string") &&
+    (addedBy.slug === null || typeof addedBy.slug === "string") &&
+    (addedBy.avatarUrl === null || typeof addedBy.avatarUrl === "string") &&
     isPlaybackPosition(value.playbackStatus)
   );
 }
@@ -144,7 +140,12 @@ export function applyTrackStarted(
     currentEntry: {
       order: previousEntry?.order ?? 0,
       track: data.track,
-      status: { skipped: false, isActive: true, isPlayed: false },
+      status: {
+        skipped: false,
+        isActive: true,
+        isPlayed: false,
+        ownerOrderLocked: previousEntry?.status.ownerOrderLocked ?? false,
+      },
       addedBy: data.addedBy,
       entryId: data.entryId,
       story: previousEntry?.story ?? null,

--- a/src/features/room/page/ui/RoomPlaybackScreen.tsx
+++ b/src/features/room/page/ui/RoomPlaybackScreen.tsx
@@ -24,7 +24,7 @@ import {
   writeStoredRoomJoinPassword,
 } from "@/src/features/room/join/lib/roomJoinPasswordStorage";
 import {
-  isPasswordRequiredError,
+  isRoomAccessDeniedError,
   shouldKeepPasswordFormAfterSubmit,
 } from "@/src/features/room/join/model/roomJoinErrors";
 import YouTubePlayer from "@/src/features/playlist/player/ui/YouTubePlayer";
@@ -232,7 +232,7 @@ export default function RoomPlaybackScreen() {
 
         const err = error as ApiError;
 
-        if (joinPassword) {
+        if (joinPassword && isRoomAccessDeniedError(err)) {
           clearStoredRoomJoinPassword(slug);
           setJoinStateSlug(slug);
           setRoomPassword(null);
@@ -241,10 +241,10 @@ export default function RoomPlaybackScreen() {
           return;
         }
 
-        if (requiresPassword && isPasswordRequiredError(err)) {
+        if (requiresPassword && isRoomAccessDeniedError(err)) {
           setJoinStateSlug(slug);
           setRoomPassword(null);
-          setJoinErrorMessage("비밀번호 입력이 필요한 방입니다.");
+          setJoinErrorMessage(err.message);
           setStatus("needs-password");
           return;
         }

--- a/src/features/room/participants/model/participantIdentity.test.ts
+++ b/src/features/room/participants/model/participantIdentity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { PlaylistParticipant } from "@/src/features/playlist/model/types";
+import type { User } from "@/src/features/user/model/types";
+import {
+  getParticipantIdentityKey,
+  getParticipantUserSlug,
+  isSameUser,
+} from "./participantIdentity";
+
+const participant = (
+  overrides: Partial<PlaylistParticipant> = {},
+): PlaylistParticipant => ({
+  participantType: "USER",
+  participantId: "participant-1",
+  userSlug: "member",
+  nickname: "같은닉네임",
+  profileImageUrl: null,
+  ...overrides,
+});
+
+describe("participantIdentity", () => {
+  it("목록 key는 participantId, 회원 주소는 userSlug만 사용한다", () => {
+    expect(getParticipantIdentityKey(participant())).toBe(
+      "participant:participant-1",
+    );
+    expect(getParticipantUserSlug(participant())).toBe("member");
+    expect(
+      getParticipantUserSlug(
+        participant({ participantId: "u_inferred", userSlug: null }),
+      ),
+    ).toBeNull();
+    expect(
+      getParticipantUserSlug({
+        ...participant({ userSlug: null }),
+        slug: "legacy-must-be-ignored",
+      } as PlaylistParticipant & { slug: string }),
+    ).toBeNull();
+  });
+
+  it("닉네임이 같아도 userSlug가 다르면 같은 회원으로 보지 않는다", () => {
+    const me: User = {
+      slug: "me",
+      nickname: "같은닉네임",
+      profileImageUrl: null,
+      userId: 1,
+    };
+    expect(isSameUser(participant({ userSlug: "other" }), me)).toBe(false);
+    expect(isSameUser(participant({ userSlug: "me" }), me)).toBe(true);
+  });
+});

--- a/src/features/room/participants/model/participantIdentity.ts
+++ b/src/features/room/participants/model/participantIdentity.ts
@@ -1,11 +1,4 @@
-type UserLike = {
-  participantId?: string | null;
-  participantType?: string | null;
-  slug?: string | null;
-  userSlug?: string | null;
-  userId?: number | null;
-  nickname?: string | null;
-};
+import type { PlaylistParticipant } from "@/src/features/playlist/model/types";
 
 export type ParticipantKickTarget = {
   participantId?: string | null;
@@ -18,78 +11,53 @@ function normalizeIdentifier(value: string | null | undefined) {
   return normalized ? normalized : null;
 }
 
-export function getParticipantUserSlug(user: UserLike | null | undefined) {
-  if (!user) {
+export function getParticipantUserSlug(
+  participant:
+    | Pick<PlaylistParticipant, "userSlug">
+    | null
+    | undefined,
+) {
+  if (!participant) {
     return null;
   }
 
-  const directSlug = normalizeIdentifier(user.userSlug ?? user.slug);
-  if (directSlug) {
-    return directSlug;
-  }
-
-  const participantId = normalizeIdentifier(user.participantId);
-  if (user.participantType === "USER" && participantId?.startsWith("u_")) {
-    return normalizeIdentifier(participantId.slice(2));
-  }
-
-  return null;
+  return normalizeIdentifier(participant.userSlug);
 }
 
 export function isSameUser(
-  left: UserLike | null | undefined,
-  right: UserLike | null | undefined,
+  participant: PlaylistParticipant | null | undefined,
+  user: { slug?: string | null } | null | undefined,
 ) {
-  if (!left || !right) {
+  if (!participant || !user) {
     return false;
   }
 
-  const leftSlug = getParticipantUserSlug(left);
-  const rightSlug = getParticipantUserSlug(right);
-  if (leftSlug && rightSlug) {
-    return leftSlug === rightSlug;
-  }
-
-  if (left.userId != null && right.userId != null) {
-    return left.userId === right.userId;
-  }
-
-  return false;
+  const participantSlug = getParticipantUserSlug(participant);
+  const userSlug = normalizeIdentifier(user.slug);
+  return Boolean(
+    participantSlug && userSlug && participantSlug === userSlug,
+  );
 }
 
-export function isRoomOwner(
-  owner: UserLike | null | undefined,
-  user: UserLike | null | undefined,
+export function isParticipantRoomOwner(
+  owner: { slug?: string | null } | null | undefined,
+  participant: PlaylistParticipant | null | undefined,
 ) {
-  return isSameUser(owner, user);
+  const ownerSlug = normalizeIdentifier(owner?.slug);
+  const participantSlug = getParticipantUserSlug(participant);
+  return Boolean(
+    ownerSlug && participantSlug && ownerSlug === participantSlug,
+  );
 }
 
 export function getParticipantIdentityKey(
-  participant: UserLike | null | undefined,
+  participant: PlaylistParticipant,
 ) {
-  if (!participant) {
-    return "participant:unknown";
-  }
-
-  const userSlug = getParticipantUserSlug(participant);
-  if (userSlug) {
-    return `user:${userSlug}`;
-  }
-
-  const participantId = normalizeIdentifier(participant.participantId);
-  if (participantId) {
-    return `participant:${participantId}`;
-  }
-
-  if (participant.userId != null) {
-    return `legacy-user:${participant.userId}`;
-  }
-
-  return `nickname:${participant.nickname ?? "unknown"}`;
+  return `participant:${participant.participantId}`;
 }
 
 export function getParticipantKickTarget(
-  participant: UserLike,
+  participant: PlaylistParticipant,
 ): ParticipantKickTarget | null {
   const userSlug = getParticipantUserSlug(participant);
   if (userSlug) {

--- a/src/features/room/participants/ui/RoomParticipantList.tsx
+++ b/src/features/room/participants/ui/RoomParticipantList.tsx
@@ -11,7 +11,7 @@ import {
   getParticipantKickTarget,
   getParticipantKickTargetKey,
   getParticipantUserSlug,
-  isRoomOwner,
+  isParticipantRoomOwner,
   isSameUser,
   type ParticipantKickTarget,
 } from "../model/participantIdentity";
@@ -76,7 +76,7 @@ export default function RoomParticipantList({
   return (
     <div className={styles.list}>
       {participants.map((participant) => {
-        const isOwner = isRoomOwner(owner, participant);
+        const isOwner = isParticipantRoomOwner(owner, participant);
         const kickTarget = getParticipantKickTarget(participant);
         const kickTargetKey = getParticipantKickTargetKey(kickTarget);
         const participantBadgeSlug =

--- a/src/features/room/participants/ui/RoomParticipantsPanel.tsx
+++ b/src/features/room/participants/ui/RoomParticipantsPanel.tsx
@@ -1,11 +1,9 @@
 import type { PlaylistParticipant } from "@/src/features/playlist/model/types";
 import { useKickRoomParticipant } from "@/src/features/room/hooks/useKickRoomParticipant";
 import type { RoomMeta } from "@/src/features/room/model/types";
+import { isRoomOwner } from "@/src/features/room/lib/isRoomOwner";
 import type { User } from "@/src/features/user/model/types";
-import {
-  getParticipantKickTargetKey,
-  isRoomOwner,
-} from "../model/participantIdentity";
+import { getParticipantKickTargetKey } from "../model/participantIdentity";
 import RoomParticipantList from "./RoomParticipantList";
 import styles from "./RoomParticipantsPanel.module.css";
 

--- a/src/features/room/profile/model/types.ts
+++ b/src/features/room/profile/model/types.ts
@@ -2,5 +2,4 @@ export type CurrentRequesterProfile = {
   avatarUrl: string | null;
   nickname: string;
   slug: string | null;
-  userId: number | null;
 };

--- a/src/features/room/profile/ui/RoomProfilePanel.tsx
+++ b/src/features/room/profile/ui/RoomProfilePanel.tsx
@@ -30,19 +30,9 @@ function isCurrentUserProfile(
     return false;
   }
 
-  if (currentRequester.slug) {
-    return me.slug === currentRequester.slug;
-  }
-
-  if (
-    typeof me.userId === "number" &&
-    typeof currentRequester.userId === "number" &&
-    me.userId === currentRequester.userId
-  ) {
-    return true;
-  }
-
-  return me.nickname === currentRequester.nickname;
+  return Boolean(
+    currentRequester.slug && me.slug === currentRequester.slug,
+  );
 }
 
 export default function RoomProfilePanel({

--- a/src/features/room/queue/hooks/useRoomQueuePanel.ts
+++ b/src/features/room/queue/hooks/useRoomQueuePanel.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { ApiError } from "@/src/shared/api/api-error";
 import { useRoomQueue } from "@/src/features/playlist/model/useRoomQueue";
 import { useMyRoomQueue } from "@/src/features/playlist/model/useMyRoomQueue";
 import { useRoomHistory } from "@/src/features/playlist/model/useRoomHistory";
@@ -14,7 +15,9 @@ import type { RoomMeta } from "@/src/features/room/model/types";
 import type { User } from "@/src/features/user/model/types";
 import {
   isEntryRequestedByUser,
+  getMovablePersonalQueueEntryIds,
   isPendingQueueEntry,
+  isValidPersonalQueueMove,
   type QueueTab,
 } from "../model/roomQueue";
 
@@ -32,6 +35,17 @@ type MovePayload = {
   orderedPendingEntryIds: string[];
 };
 
+function getQueueErrorMessage(error: unknown) {
+  if (
+    error instanceof ApiError &&
+    error.code === "room.queue-mutation-conflict"
+  ) {
+    return "";
+  }
+
+  return error instanceof Error ? error.message : "";
+}
+
 export function useRoomQueuePanel({
   currentUser,
   isCurrentUserLoading,
@@ -42,12 +56,13 @@ export function useRoomQueuePanel({
   const [activeTab, setActiveTab] = useState<QueueTab>("all");
   const [moveErrorMessage, setMoveErrorMessage] = useState("");
   const [deleteErrorMessage, setDeleteErrorMessage] = useState("");
-  const { data: entries, isRefetching: isAllRefetching } = useRoomQueue(
-    roomSlug,
-    roomPassword,
-  );
+  const allQueueQuery = useRoomQueue(roomSlug, roomPassword);
   const {
-    data: myQueueEntries = [],
+    data: myQueueData,
+    error: myQueueError,
+    fetchNextQueuePage: fetchNextMyQueuePage,
+    hasNextPage: hasNextMyQueuePage,
+    isFetchingNextPage: isFetchingNextMyQueuePage,
     isLoading: isMyQueueLoading,
     isRefetching: isMyRefetching,
   } = useMyRoomQueue(roomSlug, roomPassword, Boolean(currentUser));
@@ -61,9 +76,19 @@ export function useRoomQueuePanel({
   const deleteMyQueueEntry = useDeleteMyQueueEntry();
   const deleteRoomQueueEntries = useDeleteRoomQueueEntries();
 
-  const allEntries = entries;
+  const queueErrorMessage =
+    activeTab === "all"
+      ? getQueueErrorMessage(allQueueQuery.error)
+      : activeTab === "mine"
+        ? getQueueErrorMessage(myQueueError)
+        : "";
+
+  const allEntries = allQueueQuery.data.pages.flatMap((page) => page.items);
+  const allPendingCount =
+    allQueueQuery.data.pages[0]?.totalPendingCount ?? 0;
   const isOwner = isRoomOwner(roomMeta?.owner, currentUser);
-  const myEntries = myQueueEntries;
+  const myEntries = myQueueData?.pages.flatMap((page) => page.items) ?? [];
+  const myPendingCount = myQueueData?.pages[0]?.totalPendingCount ?? 0;
   const canDeleteEntry = (entry: PlaylistEntry) =>
     isPendingQueueEntry(entry) && isEntryRequestedByUser(entry, currentUser);
   const canDeleteEntryAsOwner = (entry: PlaylistEntry) =>
@@ -150,11 +175,26 @@ export function useRoomQueuePanel({
     orderedPendingEntryIds,
   }: MovePayload) => {
     setMoveErrorMessage("");
+    const movableEntryIds = getMovablePersonalQueueEntryIds(myEntries);
+    const movableEntryIdSet = new Set(movableEntryIds);
+    if (!isValidPersonalQueueMove(
+      movableEntryIdSet,
+      movedEntryId,
+      beforeEntryId,
+    )) {
+      setMoveErrorMessage(
+        "방장이 순서를 지정한 곡은 변경할 수 없어요.",
+      );
+      return;
+    }
+
     moveMyQueueEntry.mutate(
       {
         beforeEntryId,
         movedEntryId,
-        orderedPendingEntryIds,
+        orderedPendingEntryIds: orderedPendingEntryIds.filter((entryId) =>
+          movableEntryIdSet.has(entryId),
+        ),
         password: roomPassword,
         slug: roomSlug,
       },
@@ -171,6 +211,7 @@ export function useRoomQueuePanel({
   return {
     activeTab,
     allEntries,
+    allPendingCount,
     canDeleteEntry,
     canDeleteEntryAsOwner,
     deleteErrorMessage,
@@ -182,16 +223,28 @@ export function useRoomQueuePanel({
     handleMoveMyEntry,
     handleMoveRoomEntry,
     hasNextHistoryPage: historyQuery.hasNextPage,
+    hasNextAllQueuePage: allQueueQuery.hasNextPage,
+    hasNextMyQueuePage,
     historyEntries:
       historyQuery.data?.flatMap((page) => page.items) ?? [],
     historyErrorMessage: historyQuery.error?.message ?? "",
     isFetchingNextHistoryPage: historyQuery.isFetchingNextPage,
     isOwner,
-    isRefetching: isAllRefetching || isMyRefetching,
+    isFetchingNextAllQueuePage: allQueueQuery.isFetchingNextPage,
+    isFetchingNextMyQueuePage,
+    isRefetching: allQueueQuery.isRefetching || isMyRefetching,
     moveErrorMessage,
     moveMyQueueEntry,
     moveRoomQueueEntry,
     myEntries,
+    myPendingCount,
+    queueErrorMessage,
+    loadNextAllQueuePage: () => {
+      void allQueueQuery.fetchNextQueuePage();
+    },
+    loadNextMyQueuePage: () => {
+      void fetchNextMyQueuePage();
+    },
     loadNextHistoryPage: () => {
       void historyQuery.fetchNextPage();
     },

--- a/src/features/room/queue/model/roomQueue.test.ts
+++ b/src/features/room/queue/model/roomQueue.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { PlaylistEntry } from "@/src/features/playlist/model/types";
+import {
+  getMovablePersonalQueueEntryIds,
+  isEntryRequestedByUser,
+  isValidPersonalQueueMove,
+} from "./roomQueue";
+
+const entry = (
+  entryId: string,
+  ownerOrderLocked: boolean,
+  slug: string | null = "me",
+): PlaylistEntry => ({
+  order: 1,
+  track: {
+    title: entryId,
+    videoId: entryId,
+    provider: "YOUTUBE",
+    durationMs: 1,
+    thumbnailUrl: null,
+  },
+  status: {
+    skipped: false,
+    isActive: false,
+    isPlayed: false,
+    ownerOrderLocked,
+  },
+  addedBy: { slug, nickname: "같은닉네임", avatarUrl: null },
+  entryId,
+  createdAtMs: 1,
+  updatedAtMs: 1,
+});
+
+describe("개인 큐 순서와 공개 식별", () => {
+  it("고정되지 않은 대기곡만 개인 순서 payload 후보에 포함한다", () => {
+    const ids = getMovablePersonalQueueEntryIds([
+      entry("locked", true),
+      entry("a", false),
+      entry("b", false),
+    ]);
+    expect(ids).toEqual(["a", "b"]);
+    expect(isValidPersonalQueueMove(new Set(ids), "a", "b")).toBe(true);
+    expect(isValidPersonalQueueMove(new Set(ids), "locked", "b")).toBe(false);
+    expect(isValidPersonalQueueMove(new Set(ids), "a", "locked")).toBe(false);
+  });
+
+  it("닉네임이 같아도 addedBy.slug가 없으면 본인 곡으로 보지 않는다", () => {
+    const me = {
+      slug: "me",
+      nickname: "같은닉네임",
+      profileImageUrl: null,
+      userId: 1,
+    };
+    expect(isEntryRequestedByUser(entry("mine", false), me)).toBe(true);
+    expect(isEntryRequestedByUser(entry("guest", false, null), me)).toBe(false);
+  });
+});

--- a/src/features/room/queue/model/roomQueue.ts
+++ b/src/features/room/queue/model/roomQueue.ts
@@ -35,6 +35,26 @@ export function isPendingQueueEntry(entry: PlaylistEntry) {
   return !entry.status.isActive && !entry.status.isPlayed && !entry.status.skipped;
 }
 
+export function getMovablePersonalQueueEntryIds(entries: PlaylistEntry[]) {
+  return entries
+    .filter(
+      (entry) =>
+        isPendingQueueEntry(entry) && !entry.status.ownerOrderLocked,
+    )
+    .map((entry) => entry.entryId);
+}
+
+export function isValidPersonalQueueMove(
+  movableEntryIds: ReadonlySet<string>,
+  movedEntryId: string,
+  beforeEntryId: string | null,
+) {
+  return (
+    movableEntryIds.has(movedEntryId) &&
+    (beforeEntryId === null || movableEntryIds.has(beforeEntryId))
+  );
+}
+
 export function isEntryRequestedByUser(
   entry: PlaylistEntry,
   currentUser: User | null | undefined,
@@ -44,16 +64,5 @@ export function isEntryRequestedByUser(
   }
 
   const requesterSlug = entry.addedBy.slug?.trim();
-  if (requesterSlug) {
-    return requesterSlug === currentUser.slug;
-  }
-
-  if (
-    typeof currentUser.userId === "number" &&
-    typeof entry.addedBy.userId === "number"
-  ) {
-    return entry.addedBy.userId === currentUser.userId;
-  }
-
-  return entry.addedBy.nickname === currentUser.nickname;
+  return Boolean(requesterSlug && requesterSlug === currentUser.slug);
 }

--- a/src/features/room/queue/ui/RoomQueueCard.tsx
+++ b/src/features/room/queue/ui/RoomQueueCard.tsx
@@ -51,7 +51,7 @@ const RoomQueueCard = forwardRef<HTMLLIElement, Props>(function RoomQueueCard(
     >
       <div className={styles.thumbnailWrap}>
         <Image
-          src={entry.track.thumbnailUrl}
+          src={entry.track.thumbnailUrl ?? "/Thumbnail.png"}
           alt={`${entry.track.title} thumbnail`}
           fill
           sizes="72px"

--- a/src/features/room/queue/ui/RoomQueueListSection.tsx
+++ b/src/features/room/queue/ui/RoomQueueListSection.tsx
@@ -22,6 +22,8 @@ type RoomQueueListSectionProps = {
   isMoveMyPending: boolean;
   isMoveRoomPending: boolean;
   isOwner: boolean;
+  hasNextAllQueuePage: boolean;
+  hasNextMyQueuePage: boolean;
   myEntries: PlaylistEntry[];
   onDeleteMyEntry: (entryId: string) => void;
   onDeleteRoomEntry: (entryId: string) => void;
@@ -40,6 +42,8 @@ export default function RoomQueueListSection({
   isMoveMyPending,
   isMoveRoomPending,
   isOwner,
+  hasNextAllQueuePage,
+  hasNextMyQueuePage,
   myEntries,
   onDeleteMyEntry,
   onDeleteRoomEntry,
@@ -54,6 +58,8 @@ export default function RoomQueueListSection({
         entries={myEntries}
         isDeletePending={isDeleteMyPending}
         isMovePending={isMoveMyPending}
+        hasUnloadedEntries={hasNextMyQueuePage}
+        moveMode="self"
         onDelete={onDeleteMyEntry}
         onMove={onMoveMyEntry}
       />
@@ -68,6 +74,8 @@ export default function RoomQueueListSection({
         entries={allEntries}
         isDeletePending={isDeleteRoomPending}
         isMovePending={isMoveRoomPending}
+        hasUnloadedEntries={hasNextAllQueuePage}
+        moveMode="owner"
         onDelete={onDeleteRoomEntry}
         onMove={onMoveRoomEntry}
       />

--- a/src/features/room/queue/ui/RoomQueuePanel.module.css
+++ b/src/features/room/queue/ui/RoomQueuePanel.module.css
@@ -46,6 +46,25 @@
   text-align: center;
 }
 
+.loadMoreButton {
+  flex-shrink: 0;
+  margin: 8px 16px 0;
+  padding: 10px 12px;
+  border: 1px solid #dedfe3;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #555b66;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+}
+
+.loadMoreButton:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
 .error {
   flex-shrink: 0;
   padding: 8px 12px;

--- a/src/features/room/queue/ui/RoomQueuePanel.tsx
+++ b/src/features/room/queue/ui/RoomQueuePanel.tsx
@@ -66,11 +66,14 @@ function RoomQueuePanelContent({
     <RoomQueuePanelView
       activeTab={queuePanel.activeTab}
       allEntries={queuePanel.allEntries}
+      allPendingCount={queuePanel.allPendingCount}
       canDeleteEntry={queuePanel.canDeleteEntry}
       canDeleteEntryAsOwner={queuePanel.canDeleteEntryAsOwner}
       deleteErrorMessage={queuePanel.deleteErrorMessage}
       emptyMessage={queuePanel.emptyMessage}
       hasNextHistoryPage={queuePanel.hasNextHistoryPage}
+      hasNextAllQueuePage={queuePanel.hasNextAllQueuePage}
+      hasNextMyQueuePage={queuePanel.hasNextMyQueuePage}
       historyEntries={queuePanel.historyEntries}
       historyErrorMessage={queuePanel.historyErrorMessage}
       isDeleteMyPending={queuePanel.deleteMyQueueEntry.isPending}
@@ -80,8 +83,12 @@ function RoomQueuePanelContent({
       isOwner={queuePanel.isOwner}
       isRefetching={queuePanel.isRefetching}
       isFetchingNextHistoryPage={queuePanel.isFetchingNextHistoryPage}
+      isFetchingNextAllQueuePage={queuePanel.isFetchingNextAllQueuePage}
+      isFetchingNextMyQueuePage={queuePanel.isFetchingNextMyQueuePage}
       moveErrorMessage={queuePanel.moveErrorMessage}
       myEntries={queuePanel.myEntries}
+      myPendingCount={queuePanel.myPendingCount}
+      queueErrorMessage={queuePanel.queueErrorMessage}
       roomPassword={roomPassword}
       roomSlug={roomSlug}
       onChangeTab={queuePanel.setActiveTab}
@@ -90,6 +97,8 @@ function RoomQueuePanelContent({
       onMoveMyEntry={queuePanel.handleMoveMyEntry}
       onMoveRoomEntry={queuePanel.handleMoveRoomEntry}
       onLoadMoreHistory={queuePanel.loadNextHistoryPage}
+      onLoadMoreAllQueue={queuePanel.loadNextAllQueuePage}
+      onLoadMoreMyQueue={queuePanel.loadNextMyQueuePage}
     />
   );
 }

--- a/src/features/room/queue/ui/RoomQueuePanelView.tsx
+++ b/src/features/room/queue/ui/RoomQueuePanelView.tsx
@@ -20,11 +20,14 @@ type MovePayload = {
 type RoomQueuePanelViewProps = {
   activeTab: QueueTab;
   allEntries: PlaylistEntry[];
+  allPendingCount: number;
   canDeleteEntry: (entry: PlaylistEntry) => boolean;
   canDeleteEntryAsOwner: (entry: PlaylistEntry) => boolean;
   deleteErrorMessage: string;
   emptyMessage: string;
   hasNextHistoryPage: boolean;
+  hasNextAllQueuePage: boolean;
+  hasNextMyQueuePage: boolean;
   historyEntries: RoomHistoryEntry[];
   historyErrorMessage: string;
   isDeleteMyPending: boolean;
@@ -34,8 +37,12 @@ type RoomQueuePanelViewProps = {
   isOwner: boolean;
   isRefetching: boolean;
   isFetchingNextHistoryPage: boolean;
+  isFetchingNextAllQueuePage: boolean;
+  isFetchingNextMyQueuePage: boolean;
   moveErrorMessage: string;
   myEntries: PlaylistEntry[];
+  myPendingCount: number;
+  queueErrorMessage: string;
   roomPassword?: string | null;
   roomSlug: string;
   onChangeTab: (tab: QueueTab) => void;
@@ -44,16 +51,21 @@ type RoomQueuePanelViewProps = {
   onMoveMyEntry: (payload: MovePayload) => void;
   onMoveRoomEntry: (payload: MovePayload) => void;
   onLoadMoreHistory: () => void;
+  onLoadMoreAllQueue: () => void;
+  onLoadMoreMyQueue: () => void;
 };
 
 export default function RoomQueuePanelView({
   activeTab,
   allEntries,
+  allPendingCount,
   canDeleteEntry,
   canDeleteEntryAsOwner,
   deleteErrorMessage,
   emptyMessage,
   hasNextHistoryPage,
+  hasNextAllQueuePage,
+  hasNextMyQueuePage,
   historyEntries,
   historyErrorMessage,
   isDeleteMyPending,
@@ -63,8 +75,12 @@ export default function RoomQueuePanelView({
   isOwner,
   isRefetching,
   isFetchingNextHistoryPage,
+  isFetchingNextAllQueuePage,
+  isFetchingNextMyQueuePage,
   moveErrorMessage,
   myEntries,
+  myPendingCount,
+  queueErrorMessage,
   roomPassword,
   roomSlug,
   onChangeTab,
@@ -73,13 +89,15 @@ export default function RoomQueuePanelView({
   onMoveMyEntry,
   onMoveRoomEntry,
   onLoadMoreHistory,
+  onLoadMoreAllQueue,
+  onLoadMoreMyQueue,
 }: RoomQueuePanelViewProps) {
   return (
     <div className={styles.root}>
       <RoomQueueTabs
         activeTab={activeTab}
-        allCount={allEntries.length}
-        myCount={myEntries.length}
+        allCount={allPendingCount}
+        myCount={myPendingCount}
         onChange={onChangeTab}
       />
       <div className={styles.listArea}>
@@ -103,6 +121,8 @@ export default function RoomQueuePanelView({
             isMoveMyPending={isMoveMyPending}
             isMoveRoomPending={isMoveRoomPending}
             isOwner={isOwner}
+            hasNextAllQueuePage={hasNextAllQueuePage}
+            hasNextMyQueuePage={hasNextMyQueuePage}
             myEntries={myEntries}
             onDeleteMyEntry={onDeleteMyEntry}
             onDeleteRoomEntry={onDeleteRoomEntry}
@@ -120,6 +140,9 @@ export default function RoomQueuePanelView({
       {historyErrorMessage ? (
         <div className={styles.error}>{historyErrorMessage}</div>
       ) : null}
+      {queueErrorMessage ? (
+        <div className={styles.error}>{queueErrorMessage}</div>
+      ) : null}
       {isMoveMyPending || isMoveRoomPending ? (
         <div className={styles.refreshing}>큐 순서를 변경하는 중...</div>
       ) : null}
@@ -128,6 +151,26 @@ export default function RoomQueuePanelView({
       ) : null}
       {isRefetching ? (
         <div className={styles.refreshing}>최신 목록으로 갱신 중...</div>
+      ) : null}
+      {activeTab === "all" && hasNextAllQueuePage ? (
+        <button
+          type="button"
+          className={styles.loadMoreButton}
+          disabled={isFetchingNextAllQueuePage}
+          onClick={onLoadMoreAllQueue}
+        >
+          {isFetchingNextAllQueuePage ? "불러오는 중..." : "대기곡 더 보기"}
+        </button>
+      ) : null}
+      {activeTab === "mine" && hasNextMyQueuePage ? (
+        <button
+          type="button"
+          className={styles.loadMoreButton}
+          disabled={isFetchingNextMyQueuePage}
+          onClick={onLoadMoreMyQueue}
+        >
+          {isFetchingNextMyQueuePage ? "불러오는 중..." : "내 신청곡 더 보기"}
+        </button>
       ) : null}
       {activeTab !== "history" ? (
         <div className={styles.addTrackDock}>

--- a/src/features/room/queue/ui/RoomQueueSortableList.module.css
+++ b/src/features/room/queue/ui/RoomQueueSortableList.module.css
@@ -4,6 +4,8 @@
 }
 
 .fixedTopList {
+  margin: 0;
+  padding: 0;
   list-style: none;
   overflow-x: hidden;
 }

--- a/src/features/room/queue/ui/RoomQueueSortableList.test.tsx
+++ b/src/features/room/queue/ui/RoomQueueSortableList.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import type { ImgHTMLAttributes } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { PlaylistEntry } from "@/src/features/playlist/model/types";
+import RoomQueueSortableList from "./RoomQueueSortableList";
+
+vi.mock("next/image", () => ({
+  default: ({ alt, ...props }: ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}));
+
+const entry = (entryId: string, ownerOrderLocked: boolean): PlaylistEntry => ({
+  order: 1,
+  track: {
+    title: entryId,
+    videoId: entryId,
+    provider: "YOUTUBE",
+    durationMs: 1,
+    thumbnailUrl: null,
+  },
+  status: {
+    skipped: false,
+    isActive: false,
+    isPlayed: false,
+    ownerOrderLocked,
+  },
+  addedBy: { slug: "me", nickname: "나", avatarUrl: null },
+  entryId,
+  createdAtMs: 1,
+  updatedAtMs: 1,
+});
+
+describe("RoomQueueSortableList", () => {
+  it("개인 순서에서는 고정곡을 앞에 두고 이동 기능을 제공하지 않는다", () => {
+    const { container } = render(
+      <RoomQueueSortableList
+        emptyMessage="비었음"
+        entries={[entry("locked", true), entry("a", false), entry("b", false)]}
+        moveMode="self"
+      />,
+    );
+
+    const rows = [...container.querySelectorAll("li")];
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("locked"),
+      expect.stringContaining("a"),
+      expect.stringContaining("b"),
+    ]);
+    expect(rows[0]).toHaveAttribute("data-drag-disabled", "true");
+    expect(
+      screen.queryByLabelText("locked 순서 변경"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("a 순서 변경")).toBeInTheDocument();
+  });
+
+  it("방장 순서에서는 고정곡도 이동 대상으로 포함한다", () => {
+    render(
+      <RoomQueueSortableList
+        emptyMessage="비었음"
+        entries={[entry("locked", true), entry("a", false)]}
+        moveMode="owner"
+      />,
+    );
+
+    expect(screen.getByLabelText("locked 순서 변경")).toBeInTheDocument();
+  });
+});

--- a/src/features/room/queue/ui/RoomQueueSortableList.tsx
+++ b/src/features/room/queue/ui/RoomQueueSortableList.tsx
@@ -37,8 +37,10 @@ type Props = {
   canDeleteEntry?: (entry: PlaylistEntry) => boolean;
   emptyMessage: string;
   entries: PlaylistEntry[];
+  hasUnloadedEntries?: boolean;
   isDeletePending?: boolean;
   isMovePending?: boolean;
+  moveMode: "owner" | "self";
   onDelete?: (entryId: string) => void;
   onMove?: (payload: MovePayload) => void;
 };
@@ -101,8 +103,10 @@ export default function RoomQueueSortableList({
   canDeleteEntry,
   emptyMessage,
   entries,
+  hasUnloadedEntries = false,
   isDeletePending = false,
   isMovePending = false,
+  moveMode,
   onDelete,
   onMove,
 }: Props) {
@@ -112,9 +116,24 @@ export default function RoomQueueSortableList({
   const fixedEntries = entries.filter(
     (entry) => !isPendingQueueEntry(entry) && !entry.status.isActive,
   );
+  const lockedPendingEntries = useMemo(
+    () =>
+      moveMode === "self"
+        ? entries.filter(
+            (entry) =>
+              isPendingQueueEntry(entry) && entry.status.ownerOrderLocked,
+          )
+        : [],
+    [entries, moveMode],
+  );
   const pendingEntriesFromProps = useMemo(
-    () => entries.filter(isPendingQueueEntry),
-    [entries],
+    () =>
+      entries.filter(
+        (entry) =>
+          isPendingQueueEntry(entry) &&
+          (moveMode === "owner" || !entry.status.ownerOrderLocked),
+      ),
+    [entries, moveMode],
   );
   const pendingEntryIdsKey = useMemo(
     () => pendingEntriesFromProps.map((entry) => entry.entryId).join("\u001f"),
@@ -182,13 +201,17 @@ export default function RoomQueueSortableList({
     }
 
     const reorderedEntries = arrayMove(pendingEntries, oldIndex, newIndex);
+    const beforeEntryId = reorderedEntries[newIndex + 1]?.entryId ?? null;
+    if (hasUnloadedEntries && beforeEntryId === null) {
+      return;
+    }
     setPendingOrder({
       orderedEntryIds: reorderedEntries.map((entry) => entry.entryId),
       sourceEntryIdsKey: pendingEntryIdsKey,
     });
 
     onMove?.({
-      beforeEntryId: reorderedEntries[newIndex + 1]?.entryId ?? null,
+      beforeEntryId,
       movedEntryId: activeEntryId,
       orderedPendingEntryIds: reorderedEntries.map((entry) => entry.entryId),
     });
@@ -207,6 +230,20 @@ export default function RoomQueueSortableList({
               key={entry.entryId}
               entry={entry}
               data-drag-disabled="true"
+            />
+          ))}
+        </ul>
+      ) : null}
+      {lockedPendingEntries.length > 0 ? (
+        <ul className={styles.fixedTopList}>
+          {lockedPendingEntries.map((entry) => (
+            <RoomQueueCard
+              key={entry.entryId}
+              entry={entry}
+              data-drag-disabled="true"
+              isDeletePending={isDeletePending}
+              onDelete={onDelete}
+              showDeleteButton={canDeleteEntry?.(entry) ?? true}
             />
           ))}
         </ul>

--- a/src/features/room/queue/ui/RoomQueueTabs.test.tsx
+++ b/src/features/room/queue/ui/RoomQueueTabs.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import RoomQueueTabs from "./RoomQueueTabs";
+
+it("로드된 행 수와 무관한 서버 totalPendingCount를 탭 수로 표시한다", () => {
+  render(
+    <RoomQueueTabs
+      activeTab="all"
+      allCount={237}
+      myCount={104}
+      onChange={vi.fn()}
+    />,
+  );
+
+  expect(screen.getByRole("tab", { name: /전체 트랙\s*237/ })).toBeVisible();
+  expect(screen.getByRole("tab", { name: /내 신청곡\s*104/ })).toBeVisible();
+});

--- a/src/shared/api/websocket/createStompClient.ts
+++ b/src/shared/api/websocket/createStompClient.ts
@@ -2,14 +2,18 @@ import { Client } from "@stomp/stompjs";
 
 type CreateStompClientOptions = {
   debugLabel?: string;
+  reconnectDelay?: number;
 };
+
+export const DEFAULT_STOMP_RECONNECT_DELAY_MS = 5000;
 
 export function createStompClient({
   debugLabel = "STOMP",
+  reconnectDelay = DEFAULT_STOMP_RECONNECT_DELAY_MS,
 }: CreateStompClientOptions = {}) {
   return new Client({
     brokerURL: process.env.NEXT_PUBLIC_WS_URL,
-    reconnectDelay: 5000,
+    reconnectDelay,
     heartbeatIncoming: 4000,
     heartbeatOutgoing: 4000,
     debug: (message) => {

--- a/src/shared/api/websocket/stompConnection.ts
+++ b/src/shared/api/websocket/stompConnection.ts
@@ -1,5 +1,8 @@
 import type { IFrame } from "@stomp/stompjs";
-import { createStompClient } from "./createStompClient";
+import {
+  createStompClient,
+  DEFAULT_STOMP_RECONNECT_DELAY_MS,
+} from "./createStompClient";
 
 type SocketListener = {
   onConnect?: (frame: IFrame) => void;
@@ -46,11 +49,17 @@ client.onWebSocketClose = (event) => {
 };
 
 export function connectSocket() {
+  client.reconnectDelay = DEFAULT_STOMP_RECONNECT_DELAY_MS;
   client.activate();
 }
 
 export function disconnectSocket() {
   client.deactivate();
+}
+
+export function stopSocketAutoReconnect() {
+  client.reconnectDelay = 0;
+  void client.deactivate();
 }
 
 export function getSocketClient() {


### PR DESCRIPTION
## 요약
- 큐 조회를 첫 페이지 + cursor/queueRevision 기반 infinite pagination으로 전환했습니다.
- ownerOrderLocked, 공개 식별자, room.access-denied, strict join event, thumbnail 계약을 반영했습니다.
- user.session-replaced 시 해당 방 연결의 재접속만 중단하고 follow presence 연결은 유지합니다.
- 특정 계정 방 입장 장애를 프론트 회귀로 오인한 진단과 임시 우회 흔적을 정정했습니다.

## 검증
- npm run test (42 files / 100 tests)
- npm run lint
- npm run build
- fresh read-only QA: pass

## 의존성
- stacked PR이며 base는 feat/backend-core-v26-7-1 (PR #28)입니다.
- 실제 backend 다중 창 session replacement E2E는 v26.8 환경에서 수동 확인이 필요합니다.