### PR TITLE
fix: 설정 칭호와 프로필 수정 계약 정정

### DIFF
--- a/.agents/skills/queuing-feature-delivery/SKILL.md
+++ b/.agents/skills/queuing-feature-delivery/SKILL.md
@@ -22,7 +22,7 @@ Run a bounded delivery pipeline from request to draft PR. Read `references/deliv
    - If unrelated changes are present, stop and ask which files belong to this delivery.
    - If all existing changes are explicitly in scope, preserve them and create the delivery branch without stashing or resetting.
 3. Create or resume `docs/exec-plans/active/YYYY-MM-DD-short-slug/` with `plan.md` and `delivery-state.md`.
-4. Create the branch named by the policy. Do not implement feature work directly on the default branch.
+4. Switch to or create the delivery branch selected by the policy. The repository default is the shared `dev` branch; use a scoped branch only when the user explicitly requests one. Do not implement feature work directly on the default branch.
 5. Classify boundaries and record `selected_skills` before editing.
    - Use `queuing-orchestrator` for complex or cross-boundary work.
    - Use `queuing-api-boundary` for API, payload, hook, type, header, or cache work.
@@ -55,7 +55,7 @@ Run a bounded delivery pipeline from request to draft PR. Read `references/deliv
 
 ## Outputs
 
-- scoped feature branch and intentional commit
+- shared `dev` branch or explicitly requested scoped branch, plus intentional commits
 - active execution-plan artifacts and QA evidence
 - draft pull request using the repository template
 - delivery-state update with branch, PR, CI state, and next action

--- a/.agents/skills/queuing-feature-delivery/references/delivery-policy.md
+++ b/.agents/skills/queuing-feature-delivery/references/delivery-policy.md
@@ -1,6 +1,14 @@
 # Feature Delivery Policy
 
-## Branch Naming
+## Branch Selection
+
+Use the shared `dev` branch for normal feature, fix, refactor, and maintenance delivery. Do not create a per-feature branch unless the user explicitly requests one.
+
+- If `dev` does not exist locally or remotely, create it once from the latest remote default branch.
+- If work already has a published PR, finish that review cycle on its existing head branch rather than moving it to `dev`.
+- Do not implement directly on the remote default branch.
+
+When the user explicitly requests a scoped branch, choose its name from the request:
 
 Choose the prefix from the request:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Most project risk is at API/UI/state boundaries: API payload shape, React Query 
 
 - Use TanStack Query for server state and invalidate every query affected by a mutation.
 - Use local component state for transient UI state unless the state must be shared across screens.
-- For feature, fix, or refactor requests intended for repository delivery, use `.agents/skills/queuing-feature-delivery/SKILL.md`; it owns the branch, specialist routing, QA, commit, push, and draft PR flow. Skip Git/GitHub delivery only when the user explicitly requests local-only work.
+- For feature, fix, or refactor requests intended for repository delivery, use `.agents/skills/queuing-feature-delivery/SKILL.md`; it owns specialist routing, QA, commit, push, and draft PR flow. Skip Git/GitHub delivery only when the user explicitly requests local-only work.
+- Use the shared `dev` branch for ongoing development. Do not create per-feature branches unless the user explicitly asks for one. If `dev` does not exist, create it once from the latest remote default branch. Finish an already-published PR on its existing head branch instead of moving it mid-review.
 - For an existing PR with failing checks or review feedback, use `.agents/skills/queuing-pr-review-cycle/SKILL.md`.
 - For implementation, review, or refactoring, read `ARCHITECTURE.md` before editing and keep its documented boundaries in sync with structural changes.
 - For complex feature work, API troubleshooting, or repeated QA flows, start from `.agents/skills/queuing-orchestrator/SKILL.md`.

--- a/docs/agent-harness/context-ledger.md
+++ b/docs/agent-harness/context-ledger.md
@@ -1,6 +1,6 @@
 # Queuing Context Ledger
 
-Last refreshed: 2026-07-12
+Last refreshed: 2026-08-04
 
 ## Purpose
 
@@ -34,6 +34,7 @@ For simple one-file fixes, `AGENTS.md` plus direct code inspection is enough.
 - Server state is managed through TanStack Query.
 - The highest-risk boundary is API payload shape -> hook -> UI state -> query invalidation.
 - Modal, room, queue, websocket, password, and thumbnail flows need explicit error and loading paths.
+- Ongoing development uses the shared `dev` branch. Do not create per-feature branches unless explicitly requested; complete already-published PRs on their existing head branches.
 
 ## Harness Context
 

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/api-contract.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/api-contract.md
@@ -1,0 +1,23 @@
+# API Contract
+
+## GET /api/v1/users/me/badges
+
+- 인증된 사용자가 획득했고 현재 사용할 수 있는 칭호만 반환한다.
+- 설정 칭호 옵션은 `result.badges`만 사용한다.
+- 현재 선택값은 `result.representativeBadge`를 우선 사용하고, 없으면 `badges[].representative`에서 찾는다.
+- 설정 화면에서는 공개 카탈로그 `GET /api/v1/badges`와 획득 목록을 합치지 않는다.
+
+## PATCH /api/v1/user-profiles/me
+
+- request:
+  - `nickname`: required, 2~20자
+  - `statusMessage`: optional nullable string, 최대 255자, 줄바꿈 금지
+  - 빈 문자열 `statusMessage`는 삭제 의도다.
+- response: `result: boolean`
+- 한 줄 메시지만 수정해도 현재 서버 닉네임을 함께 보낸다.
+- boolean 응답을 사용자 캐시로 저장하지 않는다.
+- 성공 후 `userKeys.me()`와 현재 slug의 `userKeys.profile(slug)`를 재검증한다.
+
+## Account Cache Boundary
+
+- `badgeKeys.me()`는 사용자 slug 비스코프이므로 로그아웃 성공 시 제거한다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
@@ -1,0 +1,12 @@
+# Delivery State
+
+- status: local-review
+- branch: feat/settings-badge-catalog
+- base: main
+- issue:
+- pr:
+- selected_skills: queuing-feature-delivery, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-qa-reviewer
+- local_qa: targeted 2 files / 5 tests pass; lint pass; full test 43 files / 102 tests pass; build pass; fresh QA pass
+- ci:
+- review_threads:
+- next_action: 기능 커밋을 생성하고 branch push 후 Draft PR을 연다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
@@ -1,12 +1,12 @@
 # Delivery State
 
-- status: ci-pending
+- status: local-review
 - branch: feat/settings-badge-catalog
 - base: main
 - issue:
 - pr: https://github.com/Queuing-org/frontend/pull/31
 - selected_skills: queuing-feature-delivery, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-qa-reviewer
-- local_qa: targeted 2 files / 5 tests pass; lint pass; full test 43 files / 102 tests pass; build pass; fresh QA pass
-- ci: pending
-- review_threads:
-- next_action: PR #31 CI와 human review를 확인한다.
+- local_qa: targeted 6 files / 14 tests pass; lint pass; full test 46 files / 108 tests pass; build pass; fresh QA pass
+- ci: GitHub Actions, Vercel pass on 242e190
+- review_threads: none; user contract correction received in chat
+- next_action: 정정 커밋을 PR #31 브랜치에 push하고 PR 설명과 CI 상태를 갱신한다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
@@ -1,12 +1,12 @@
 # Delivery State
 
-- status: local-review
+- status: ci-pending
 - branch: feat/settings-badge-catalog
 - base: main
 - issue:
-- pr:
+- pr: https://github.com/Queuing-org/frontend/pull/31
 - selected_skills: queuing-feature-delivery, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-qa-reviewer
 - local_qa: targeted 2 files / 5 tests pass; lint pass; full test 43 files / 102 tests pass; build pass; fresh QA pass
-- ci:
+- ci: pending
 - review_threads:
-- next_action: 기능 커밋을 생성하고 branch push 후 Draft PR을 연다.
+- next_action: PR #31 CI와 human review를 확인한다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/delivery-state.md
@@ -1,12 +1,12 @@
 # Delivery State
 
-- status: local-review
+- status: ci-pending
 - branch: feat/settings-badge-catalog
 - base: main
 - issue:
 - pr: https://github.com/Queuing-org/frontend/pull/31
 - selected_skills: queuing-feature-delivery, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-qa-reviewer
 - local_qa: targeted 6 files / 14 tests pass; lint pass; full test 46 files / 108 tests pass; build pass; fresh QA pass
-- ci: GitHub Actions, Vercel pass on 242e190
+- ci: pending on 0524085
 - review_threads: none; user contract correction received in chat
-- next_action: 정정 커밋을 PR #31 브랜치에 push하고 PR 설명과 CI 상태를 갱신한다.
+- next_action: PR #31 최신 CI와 human review를 확인한다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
@@ -38,7 +38,7 @@
 - [x] commit, push, Draft PR
 - [x] 사용자 계약 정정 구현
 - [x] 정정 후 전체 검증 및 fresh QA
-- [ ] PR #31 update
+- [x] PR #31 update
 
 ## Verification
 

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
@@ -31,7 +31,7 @@
 - [x] 설정 칭호 데이터 흐름 전환
 - [x] 대상 테스트 및 전체 검증
 - [x] fresh QA review
-- [ ] commit, push, Draft PR
+- [x] commit, push, Draft PR
 
 ## Verification
 

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
@@ -1,21 +1,25 @@
-# 설정 칭호 카탈로그 전환
+# 설정 칭호 및 프로필 수정 계약 정정
 
 ## Scope
 
-- 설정 페이지의 칭호 목록과 획득 여부를 `GET /api/v1/badges` 응답만으로 구성한다.
-- 현재 대표 칭호는 로그인 사용자 응답의 `representativeBadge`를 사용한다.
+- 설정 페이지의 칭호 목록과 대표 칭호를 `GET /api/v1/users/me/badges` 응답만으로 구성한다.
+- `PATCH /api/v1/user-profiles/me`의 필수 `nickname`과 boolean 응답 계약을 반영한다.
+- 닉네임과 한 줄 메시지를 각각 오른쪽 `수정` 버튼으로 독립 저장한다.
 - 대표 칭호 변경 mutation과 기존 공개/내 칭호 캐시 갱신 동작은 유지한다.
 
 ## Acceptance Criteria
 
-- 설정 페이지 진입 시 칭호 목록 때문에 `/api/v1/users/me/badges`를 조회하지 않는다.
-- 카탈로그의 `acquired: true` 칭호만 선택할 수 있다.
-- 카탈로그 순서 안에서 획득 칭호가 먼저 표시되는 기존 UI 동작을 유지한다.
+- 설정 페이지의 칭호 옵션에는 `/api/v1/users/me/badges`가 반환한 획득 칭호만 표시한다.
+- 현재 대표 칭호는 같은 응답의 `representativeBadge`로 표시한다.
 - 현재 대표 칭호가 선택값으로 표시되고 변경 시 `{ badgeCode }`가 전송된다.
+- 한 줄 메시지만 수정해도 현재 닉네임을 payload에 포함한다.
+- 프로필 수정 성공 응답 `true`를 사용자 객체로 캐시에 저장하지 않고 내 정보를 재검증한다.
+- 닉네임과 한 줄 메시지의 수정 버튼 및 submit 경로를 분리한다.
 
 ## Selected Skills
 
 - queuing-feature-delivery
+- queuing-pr-review-cycle
 - queuing-api-boundary
 - queuing-ui-flow
 - frontend-architecture-guardrails
@@ -23,7 +27,7 @@
 
 ## Commit Slices
 
-1. `feat(settings): 칭호 목록을 카탈로그 API 기준으로 전환`
+1. `feat(settings): 칭호와 프로필 수정 계약을 정정`
 
 ## Progress
 
@@ -32,6 +36,9 @@
 - [x] 대상 테스트 및 전체 검증
 - [x] fresh QA review
 - [x] commit, push, Draft PR
+- [x] 사용자 계약 정정 구현
+- [x] 정정 후 전체 검증 및 fresh QA
+- [ ] PR #31 update
 
 ## Verification
 
@@ -42,12 +49,12 @@
 
 결과:
 
-- targeted Vitest: 2 files / 5 tests pass
+- targeted Vitest: 6 files / 14 tests pass
 - lint: pass
-- full test: 43 files / 102 tests pass
+- full test: 46 files / 108 tests pass
 - build: pass
 - fresh QA: pass
 
 ## Residual Risk
 
-- 백엔드가 로그인 쿠키를 인식하지 못하면 카탈로그의 `acquired`가 모두 false가 되므로 실제 배포 환경의 세션 쿠키 전달은 수동 QA 대상이다.
+- 실제 로그인 브라우저에서 획득 칭호 조회, 대표 칭호 변경, 닉네임/한 줄 메시지 독립 저장은 수동 QA 대상이다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/plan.md
@@ -1,0 +1,53 @@
+# 설정 칭호 카탈로그 전환
+
+## Scope
+
+- 설정 페이지의 칭호 목록과 획득 여부를 `GET /api/v1/badges` 응답만으로 구성한다.
+- 현재 대표 칭호는 로그인 사용자 응답의 `representativeBadge`를 사용한다.
+- 대표 칭호 변경 mutation과 기존 공개/내 칭호 캐시 갱신 동작은 유지한다.
+
+## Acceptance Criteria
+
+- 설정 페이지 진입 시 칭호 목록 때문에 `/api/v1/users/me/badges`를 조회하지 않는다.
+- 카탈로그의 `acquired: true` 칭호만 선택할 수 있다.
+- 카탈로그 순서 안에서 획득 칭호가 먼저 표시되는 기존 UI 동작을 유지한다.
+- 현재 대표 칭호가 선택값으로 표시되고 변경 시 `{ badgeCode }`가 전송된다.
+
+## Selected Skills
+
+- queuing-feature-delivery
+- queuing-api-boundary
+- queuing-ui-flow
+- frontend-architecture-guardrails
+- queuing-qa-reviewer
+
+## Commit Slices
+
+1. `feat(settings): 칭호 목록을 카탈로그 API 기준으로 전환`
+
+## Progress
+
+- [x] 브랜치 생성 및 기존 데이터 흐름 확인
+- [x] 설정 칭호 데이터 흐름 전환
+- [x] 대상 테스트 및 전체 검증
+- [x] fresh QA review
+- [ ] commit, push, Draft PR
+
+## Verification
+
+- targeted Vitest
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+
+결과:
+
+- targeted Vitest: 2 files / 5 tests pass
+- lint: pass
+- full test: 43 files / 102 tests pass
+- build: pass
+- fresh QA: pass
+
+## Residual Risk
+
+- 백엔드가 로그인 쿠키를 인식하지 못하면 카탈로그의 `acquired`가 모두 false가 되므로 실제 배포 환경의 세션 쿠키 전달은 수동 QA 대상이다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/qa-report.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/qa-report.md
@@ -1,0 +1,27 @@
+# QA Report
+
+## Result
+
+- classification: pass
+- blocking findings: none
+
+## Boundary Review
+
+- 설정 칭호 목록과 선택 가능 여부는 `GET /api/v1/badges`의 `badges[].acquired`만 사용한다.
+- 설정 페이지에서 목록 구성을 위한 `/api/v1/users/me/badges` 조회를 제거했다.
+- 현재 대표 칭호는 기존 로그인 사용자 계약의 `representativeBadge`를 사용한다.
+- 대표 칭호 변경 성공 시 `userKeys.me()`를 재검증하므로 controlled select가 최신 대표값으로 동기화된다.
+- 삭제한 획득 칭호 병합 helper의 남은 사용처가 없다.
+
+## Verification
+
+- `npm run test -- src/features/settings/ui/ProfileSettingsTab.test.tsx src/features/badge/api/badges.test.ts`: 2 files / 5 tests pass
+- `npm run lint`: pass
+- `npm run test`: 43 files / 102 tests pass
+- `npm run build`: pass
+- `git diff --check`: pass
+- fresh read-only QA: pass
+
+## Residual Risk
+
+- 실제 로그인 브라우저에서 세션 쿠키와 함께 `/api/v1/badges`가 `acquired: true`를 반환하는 수동 확인은 수행하지 않았다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/qa-report.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/qa-report.md
@@ -7,21 +7,22 @@
 
 ## Boundary Review
 
-- 설정 칭호 목록과 선택 가능 여부는 `GET /api/v1/badges`의 `badges[].acquired`만 사용한다.
-- 설정 페이지에서 목록 구성을 위한 `/api/v1/users/me/badges` 조회를 제거했다.
-- 현재 대표 칭호는 기존 로그인 사용자 계약의 `representativeBadge`를 사용한다.
-- 대표 칭호 변경 성공 시 `userKeys.me()`를 재검증하므로 controlled select가 최신 대표값으로 동기화된다.
-- 삭제한 획득 칭호 병합 helper의 남은 사용처가 없다.
+- 설정 칭호 목록과 대표 선택값은 `GET /api/v1/users/me/badges` 응답만 사용한다.
+- 프로필 수정은 필수 nickname과 선택 statusMessage를 전송하고 boolean 결과를 반환한다.
+- 한 줄 메시지만 저장할 때 현재 서버 nickname을 포함하며 미저장 nickname draft는 보존한다.
+- 닉네임과 한 줄 메시지는 독립 form과 오른쪽 수정 버튼을 가진다.
+- 프로필 수정 성공 시 내 정보와 공개 프로필 캐시를 함께 재검증한다.
+- 로그아웃 성공 시 내 칭호 캐시를 제거해 계정 전환 시 이전 칭호 노출을 막는다.
 
 ## Verification
 
-- `npm run test -- src/features/settings/ui/ProfileSettingsTab.test.tsx src/features/badge/api/badges.test.ts`: 2 files / 5 tests pass
+- targeted Vitest: 6 files / 14 tests pass
 - `npm run lint`: pass
-- `npm run test`: 43 files / 102 tests pass
+- `npm run test`: 46 files / 108 tests pass
 - `npm run build`: pass
 - `git diff --check`: pass
 - fresh read-only QA: pass
 
 ## Residual Risk
 
-- 실제 로그인 브라우저에서 세션 쿠키와 함께 `/api/v1/badges`가 `acquired: true`를 반환하는 수동 확인은 수행하지 않았다.
+- 실제 로그인 브라우저에서 획득 칭호 조회, 대표 칭호 변경, 닉네임/한 줄 메시지 독립 저장은 수동 확인하지 않았다.

--- a/docs/exec-plans/active/2026-08-04-settings-badge-catalog/review-findings.md
+++ b/docs/exec-plans/active/2026-08-04-settings-badge-catalog/review-findings.md
@@ -1,0 +1,29 @@
+# Review Findings
+
+## Context
+
+- PR: https://github.com/Queuing-org/frontend/pull/31
+- GitHub Actions/Vercel: pass on `242e190`
+- unresolved review threads: none
+- source: 사용자가 채팅에서 API 계약과 UI 요구를 정정함
+
+## Actionable
+
+1. 설정 칭호 목록과 대표 칭호의 단일 소스를 `GET /api/v1/users/me/badges`로 변경한다.
+2. 프로필 수정 payload에 `nickname`을 필수로 포함하고 response를 boolean으로 처리한다.
+3. 닉네임과 한 줄 메시지에 각각 오른쪽 `수정` 버튼과 독립 submit 경로를 제공한다.
+
+## Resolved / Duplicate / Conflict
+
+- 공개 프로필 캐시 무효화 누락: `useUpdateMe` 성공 시 `me`와 현재 slug의 공개 프로필을 함께 무효화하고 테스트함.
+- 계정 전환 시 내 칭호 캐시 잔존: 로그아웃 성공 시 `badgeKeys.me()`를 제거하고 테스트함.
+
+## External Checks
+
+- CodeRabbit: Draft라 review skipped, status success.
+- Vercel: success.
+
+## QA
+
+- fresh read-only QA: pass
+- blockers: none

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,6 +1,6 @@
 # Active Execution Plans
 
-- `2026-08-04-settings-badge-catalog`: ci-pending — Draft PR #31, 설정 페이지 칭호 목록을 `/api/v1/badges` 카탈로그 기준으로 전환
+- `2026-08-04-settings-badge-catalog`: local-review — Draft PR #31, 내 칭호 및 프로필 수정 계약 정정 QA 통과
 - `2026-07-12-profile-stats-moderation`: ci-pending — PR #26 리뷰 대응 완료, CodeRabbit 재검토 대기
 - `2026-07-25-preupload-room-thumbnail`: ready — PR #27 태그 최대 3개 후속 변경 및 CI 통과, human review 대기
 - `2026-07-29-backend-core-v26-7-1`: ci-pending — Draft PR #28, backend-core v26.7.1 전체 프론트 마이그레이션

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,5 +1,6 @@
 # Active Execution Plans
 
+- `2026-08-04-settings-badge-catalog`: local-review — 설정 페이지 칭호 목록을 `/api/v1/badges` 카탈로그 기준으로 전환, 전체 QA 통과
 - `2026-07-12-profile-stats-moderation`: ci-pending — PR #26 리뷰 대응 완료, CodeRabbit 재검토 대기
 - `2026-07-25-preupload-room-thumbnail`: ready — PR #27 태그 최대 3개 후속 변경 및 CI 통과, human review 대기
 - `2026-07-29-backend-core-v26-7-1`: ci-pending — Draft PR #28, backend-core v26.7.1 전체 프론트 마이그레이션

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,6 +1,6 @@
 # Active Execution Plans
 
-- `2026-08-04-settings-badge-catalog`: local-review — Draft PR #31, 내 칭호 및 프로필 수정 계약 정정 QA 통과
+- `2026-08-04-settings-badge-catalog`: ci-pending — Draft PR #31, 내 칭호 및 프로필 수정 계약 정정 push 완료
 - `2026-07-12-profile-stats-moderation`: ci-pending — PR #26 리뷰 대응 완료, CodeRabbit 재검토 대기
 - `2026-07-25-preupload-room-thumbnail`: ready — PR #27 태그 최대 3개 후속 변경 및 CI 통과, human review 대기
 - `2026-07-29-backend-core-v26-7-1`: ci-pending — Draft PR #28, backend-core v26.7.1 전체 프론트 마이그레이션

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,6 +1,6 @@
 # Active Execution Plans
 
-- `2026-08-04-settings-badge-catalog`: local-review — 설정 페이지 칭호 목록을 `/api/v1/badges` 카탈로그 기준으로 전환, 전체 QA 통과
+- `2026-08-04-settings-badge-catalog`: ci-pending — Draft PR #31, 설정 페이지 칭호 목록을 `/api/v1/badges` 카탈로그 기준으로 전환
 - `2026-07-12-profile-stats-moderation`: ci-pending — PR #26 리뷰 대응 완료, CodeRabbit 재검토 대기
 - `2026-07-25-preupload-room-thumbnail`: ready — PR #27 태그 최대 3개 후속 변경 및 CI 통과, human review 대기
 - `2026-07-29-backend-core-v26-7-1`: ci-pending — Draft PR #28, backend-core v26.7.1 전체 프론트 마이그레이션

--- a/src/features/auth/logout/model/useLogout.test.tsx
+++ b/src/features/auth/logout/model/useLogout.test.tsx
@@ -1,0 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { badgeKeys } from "@/src/features/badge/model/queryKeys";
+import { userKeys } from "@/src/features/user/model/queryKeys";
+import { logoutApi } from "../api/logout";
+import { useLogout } from "./useLogout";
+
+vi.mock("../api/logout", () => ({
+  logoutApi: vi.fn(),
+}));
+
+describe("useLogout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("로그아웃 성공 시 내 정보와 계정별 칭호 캐시를 정리한다", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(userKeys.me(), { slug: "first-user" });
+    queryClient.setQueryData(badgeKeys.me(), {
+      badges: [{ badgeCode: "FIRST_BADGE" }],
+    });
+    vi.mocked(logoutApi).mockResolvedValue();
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useLogout(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(queryClient.getQueryData(userKeys.me())).toBeNull();
+    expect(queryClient.getQueryData(badgeKeys.me())).toBeUndefined();
+  });
+});

--- a/src/features/auth/logout/model/useLogout.ts
+++ b/src/features/auth/logout/model/useLogout.ts
@@ -4,6 +4,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { logoutApi } from "../api/logout";
 import { userKeys } from "@/src/features/user/model/queryKeys";
+import { badgeKeys } from "@/src/features/badge/model/queryKeys";
 
 export function useLogout() {
   const qc = useQueryClient();
@@ -12,6 +13,7 @@ export function useLogout() {
     mutationFn: () => logoutApi(),
     onSuccess: () => {
       qc.setQueryData(userKeys.me(), null);
+      qc.removeQueries({ queryKey: badgeKeys.me() });
     },
   });
 }

--- a/src/features/badge/api/badges.test.ts
+++ b/src/features/badge/api/badges.test.ts
@@ -62,6 +62,9 @@ describe("칭호 API 계약", () => {
     });
 
     await expect(fetchMyBadges()).resolves.toEqual(response);
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      "/api/v1/users/me/badges",
+    );
   });
 
   it("대표 칭호 설정 payload는 badgeCode만 전송한다", async () => {

--- a/src/features/badge/api/badges.test.ts
+++ b/src/features/badge/api/badges.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/src/shared/api/axiosInstance", () => ({
   },
 }));
 
-describe("v26.7.1 칭호 계약", () => {
+describe("칭호 API 계약", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -36,6 +36,7 @@ describe("v26.7.1 칭호 계약", () => {
     });
 
     await expect(fetchBadges()).resolves.toEqual(response);
+    expect(axiosInstance.get).toHaveBeenCalledWith("/api/v1/badges");
   });
 
   it("획득 칭호의 representative/acquiredAt과 대표 badgeCode를 파싱한다", async () => {

--- a/src/features/badge/model/badgeDisplay.ts
+++ b/src/features/badge/model/badgeDisplay.ts
@@ -45,17 +45,6 @@ export function getRepresentativeBadge(
   return getBadgeSummaryFromUserBadge(representativeUserBadge);
 }
 
-export function getBadgeCode(userBadge: UserBadge) {
-  return userBadge.badgeCode;
-}
-
 export function getCatalogBadgeHint(badge: BadgeCatalogItem) {
   return badge.acquisitionHint;
-}
-
-export function isCatalogBadgeAcquired(
-  badge: BadgeCatalogItem,
-  acquiredBadgeCodes: ReadonlySet<string>,
-) {
-  return badge.acquired || acquiredBadgeCodes.has(badge.badgeCode);
 }

--- a/src/features/settings/hooks/useProfileSettingsForm.test.tsx
+++ b/src/features/settings/hooks/useProfileSettingsForm.test.tsx
@@ -43,13 +43,13 @@ describe("프로필 상태 메시지 폼", () => {
 
     act(() => result.current.updateStatusMessageDraft(""));
     act(() =>
-      result.current.handleProfileSubmit({
+      result.current.handleStatusMessageSubmit({
         preventDefault: vi.fn(),
       } as unknown as React.FormEvent<HTMLFormElement>),
     );
 
     expect(mutate).toHaveBeenCalledWith(
-      { statusMessage: "" },
+      { nickname: "민지", statusMessage: "" },
       expect.any(Object),
     );
   });
@@ -59,7 +59,7 @@ describe("프로필 상태 메시지 폼", () => {
 
     act(() => result.current.updateNicknameDraft("새 닉네임"));
     act(() =>
-      result.current.handleProfileSubmit({
+      result.current.handleNicknameSubmit({
         preventDefault: vi.fn(),
       } as unknown as React.FormEvent<HTMLFormElement>),
     );
@@ -68,6 +68,41 @@ describe("프로필 상태 메시지 폼", () => {
       { nickname: "새 닉네임" },
       expect.any(Object),
     );
+  });
+
+  it("닉네임과 한 줄 메시지의 수정 가능 상태를 독립적으로 계산한다", () => {
+    const { result } = renderHook(() => useProfileSettingsForm());
+
+    expect(result.current.canUpdateNickname).toBe(false);
+    expect(result.current.canUpdateStatusMessage).toBe(false);
+
+    act(() => result.current.updateStatusMessageDraft("새 메시지"));
+
+    expect(result.current.canUpdateNickname).toBe(false);
+    expect(result.current.canUpdateStatusMessage).toBe(true);
+  });
+
+  it("한 줄 메시지 저장은 미저장 닉네임 draft를 전송하거나 초기화하지 않는다", () => {
+    const { result } = renderHook(() => useProfileSettingsForm());
+
+    act(() => result.current.updateNicknameDraft("미저장 닉네임"));
+    act(() => result.current.updateStatusMessageDraft("새 메시지"));
+    act(() =>
+      result.current.handleStatusMessageSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>),
+    );
+
+    expect(mutate).toHaveBeenCalledWith(
+      { nickname: "민지", statusMessage: "새 메시지" },
+      expect.any(Object),
+    );
+
+    const options = mutate.mock.calls[0][1] as { onSuccess: () => void };
+    act(() => options.onSuccess());
+
+    expect(result.current.nickname).toBe("미저장 닉네임");
+    expect(result.current.statusMessage).toBe("기존 메시지");
   });
 
   it("줄바꿈을 제거하고 255자로 제한한다", () => {

--- a/src/features/settings/hooks/useProfileSettingsForm.ts
+++ b/src/features/settings/hooks/useProfileSettingsForm.ts
@@ -6,6 +6,8 @@ import { useUpdateMe } from "@/src/features/user/profile/hooks/useUpdateMe";
 import type { UpdateMePayload } from "@/src/features/user/profile/model/types";
 
 export const STATUS_MESSAGE_MAX_LENGTH = 255;
+export const NICKNAME_MIN_LENGTH = 2;
+export const NICKNAME_MAX_LENGTH = 20;
 
 export function useProfileSettingsForm() {
   const [nicknameDraft, setNicknameDraft] = useState<string | null>(null);
@@ -26,12 +28,18 @@ export function useProfileSettingsForm() {
   const nickname = nicknameDraft ?? currentNickname;
   const statusMessage = statusMessageDraft ?? currentStatusMessage;
   const trimmedNickname = nickname.trim();
-  const canUpdateProfile =
+  const isNicknameValid =
+    trimmedNickname.length >= NICKNAME_MIN_LENGTH &&
+    trimmedNickname.length <= NICKNAME_MAX_LENGTH;
+  const canUpdateNickname =
     Boolean(me) &&
-    trimmedNickname.length > 0 &&
-    (trimmedNickname !== currentNickname ||
-      (statusMessageDraft !== null &&
-        statusMessage !== currentStatusMessage)) &&
+    isNicknameValid &&
+    trimmedNickname !== currentNickname &&
+    !isUpdatingProfile;
+  const canUpdateStatusMessage =
+    Boolean(me) &&
+    statusMessageDraft !== null &&
+    statusMessage !== currentStatusMessage &&
     !isUpdatingProfile;
 
   const updateNicknameDraft = (value: string) => {
@@ -48,43 +56,52 @@ export function useProfileSettingsForm() {
     resetUpdateMe();
   };
 
-  const handleProfileSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleNicknameSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!me || !trimmedNickname) {
+    if (!me || !canUpdateNickname) {
       return;
     }
 
-    const payload: UpdateMePayload = {};
-    if (trimmedNickname !== currentNickname) {
-      payload.nickname = trimmedNickname;
-    }
-    if (
-      statusMessageDraft !== null &&
-      statusMessage !== currentStatusMessage
-    ) {
-      payload.statusMessage = statusMessage;
-    }
+    updateMe(
+      { nickname: trimmedNickname },
+      {
+        onSuccess: () => {
+          setNicknameDraft(null);
+          setSuccessMessage("사용자 이름이 변경되었습니다.");
+        },
+      },
+    );
+  };
 
-    if (Object.keys(payload).length === 0) {
+  const handleStatusMessageSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!me || !canUpdateStatusMessage) {
       return;
     }
+
+    const payload: UpdateMePayload = {
+      nickname: currentNickname,
+      statusMessage,
+    };
 
     updateMe(
       payload,
       {
         onSuccess: () => {
-          setNicknameDraft(null);
           setStatusMessageDraft(null);
-          setSuccessMessage("프로필이 변경되었습니다.");
+          setSuccessMessage("한 줄 메시지가 변경되었습니다.");
         },
       },
     );
   };
 
   return {
-    canUpdateProfile,
-    handleProfileSubmit,
+    canUpdateNickname,
+    canUpdateStatusMessage,
+    handleNicknameSubmit,
+    handleStatusMessageSubmit,
     hasProfile: Boolean(me),
     isMeError,
     isMeLoading,

--- a/src/features/settings/ui/ProfileSettingsTab.module.css
+++ b/src/features/settings/ui/ProfileSettingsTab.module.css
@@ -111,9 +111,13 @@
   border: 0;
 }
 
-.nicknameControl {
+.editableControl {
   position: relative;
   min-width: 0;
+}
+
+.editableControl .textInput {
+  padding-right: 80px;
 }
 
 .textInput,
@@ -171,11 +175,6 @@
 .badgeOptionOwned {
   color: #3c3c3c;
   font-weight: var(--fw-bold);
-}
-
-.badgeOptionLocked {
-  color: #b0b0b5;
-  font-weight: var(--fw-regular);
 }
 
 .textInput::placeholder {

--- a/src/features/settings/ui/ProfileSettingsTab.test.tsx
+++ b/src/features/settings/ui/ProfileSettingsTab.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useBadgeCatalog } from "@/src/features/badge/hooks/useBadgeCatalog";
+import { useSetRepresentativeBadge } from "@/src/features/badge/hooks/useSetRepresentativeBadge";
+import { useProfileSettingsForm } from "../hooks/useProfileSettingsForm";
+import ProfileSettingsTab from "./ProfileSettingsTab";
+
+vi.mock("next/image", () => ({
+  default: () => <span data-testid="profile-image" />,
+}));
+vi.mock("@/src/features/badge/hooks/useBadgeCatalog", () => ({
+  useBadgeCatalog: vi.fn(),
+}));
+vi.mock("@/src/features/badge/hooks/useSetRepresentativeBadge", () => ({
+  useSetRepresentativeBadge: vi.fn(),
+}));
+vi.mock("../hooks/useProfileSettingsForm", () => ({
+  useProfileSettingsForm: vi.fn(),
+}));
+vi.mock("./components/ProfileStats", () => ({
+  default: () => <div data-testid="profile-stats" />,
+}));
+
+const mutate = vi.fn();
+
+describe("설정 칭호 목록", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useProfileSettingsForm).mockReturnValue({
+      canUpdateProfile: false,
+      handleProfileSubmit: vi.fn(),
+      hasProfile: true,
+      isMeError: false,
+      isMeLoading: false,
+      isUpdatingProfile: false,
+      me: {
+        nickname: "민지",
+        profileImageUrl: null,
+        representativeBadge: {
+          badgeCode: "ROOM_CREATE_00001",
+          name: "방 팠음",
+        },
+        slug: "minji",
+      },
+      nickname: "민지",
+      profileImageSrc: "/images/default-profile.png",
+      statusMessage: "",
+      successMessage: null,
+      updateError: null,
+      updateNicknameDraft: vi.fn(),
+      updateStatusMessageDraft: vi.fn(),
+    } as ReturnType<typeof useProfileSettingsForm>);
+    vi.mocked(useBadgeCatalog).mockReturnValue({
+      data: {
+        badges: [
+          {
+            acquired: false,
+            acquisitionHint: "방을 더 만들어 보세요.",
+            active: true,
+            badgeCode: "ROOM_CREATE_00010",
+            category: "ROOM_CREATION",
+            description: "누적 방 생성 10회 달성",
+            name: "방 열 번 팠음",
+            tier: "TIER_2",
+          },
+          {
+            acquired: true,
+            acquisitionHint: "방을 생성해 보세요.",
+            active: true,
+            badgeCode: "ROOM_CREATE_00001",
+            category: "ROOM_CREATION",
+            description: "누적 방 생성 1회 달성",
+            name: "방 팠음",
+            tier: "TIER_1",
+          },
+          {
+            acquired: true,
+            acquisitionHint: "방을 두 번 생성해 보세요.",
+            active: true,
+            badgeCode: "ROOM_CREATE_00002",
+            category: "ROOM_CREATION",
+            description: "누적 방 생성 2회 달성",
+            name: "방 또 팠음",
+            tier: "TIER_1",
+          },
+        ],
+      },
+      isError: false,
+      isLoading: false,
+    } as ReturnType<typeof useBadgeCatalog>);
+    vi.mocked(useSetRepresentativeBadge).mockReturnValue({
+      error: null,
+      isPending: false,
+      mutate,
+    } as unknown as ReturnType<typeof useSetRepresentativeBadge>);
+  });
+
+  it("카탈로그 acquired 값으로 선택 가능 여부를 정하고 현재 대표 칭호를 표시한다", () => {
+    render(<ProfileSettingsTab />);
+
+    const select = screen.getByRole("combobox", { name: "칭호" });
+    const options = screen.getAllByRole("option");
+
+    expect(select).toHaveValue("ROOM_CREATE_00001");
+    expect(options.map((option) => option.textContent)).toEqual([
+      "대표 칭호 선택",
+      "방 팠음",
+      "방 또 팠음",
+      "방 열 번 팠음",
+    ]);
+    expect(screen.getByRole("option", { name: "방 팠음" })).toBeEnabled();
+    expect(
+      screen.getByRole("option", { name: "방 열 번 팠음" }),
+    ).toBeDisabled();
+  });
+
+  it("획득한 칭호를 선택하면 badgeCode만 대표 칭호 mutation에 전달한다", async () => {
+    const user = userEvent.setup();
+    render(<ProfileSettingsTab />);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "칭호" }),
+      "ROOM_CREATE_00002",
+    );
+
+    expect(mutate).toHaveBeenCalledWith({ badgeCode: "ROOM_CREATE_00002" });
+  });
+});

--- a/src/features/settings/ui/ProfileSettingsTab.test.tsx
+++ b/src/features/settings/ui/ProfileSettingsTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useBadgeCatalog } from "@/src/features/badge/hooks/useBadgeCatalog";
+import { useMyBadges } from "@/src/features/badge/hooks/useMyBadges";
 import { useSetRepresentativeBadge } from "@/src/features/badge/hooks/useSetRepresentativeBadge";
 import { useProfileSettingsForm } from "../hooks/useProfileSettingsForm";
 import ProfileSettingsTab from "./ProfileSettingsTab";
@@ -9,8 +9,8 @@ import ProfileSettingsTab from "./ProfileSettingsTab";
 vi.mock("next/image", () => ({
   default: () => <span data-testid="profile-image" />,
 }));
-vi.mock("@/src/features/badge/hooks/useBadgeCatalog", () => ({
-  useBadgeCatalog: vi.fn(),
+vi.mock("@/src/features/badge/hooks/useMyBadges", () => ({
+  useMyBadges: vi.fn(),
 }));
 vi.mock("@/src/features/badge/hooks/useSetRepresentativeBadge", () => ({
   useSetRepresentativeBadge: vi.fn(),
@@ -23,72 +23,71 @@ vi.mock("./components/ProfileStats", () => ({
 }));
 
 const mutate = vi.fn();
+const handleNicknameSubmit = vi.fn();
+const handleStatusMessageSubmit = vi.fn();
+
+function mockProfileForm(
+  overrides: Partial<ReturnType<typeof useProfileSettingsForm>> = {},
+) {
+  vi.mocked(useProfileSettingsForm).mockReturnValue({
+    canUpdateNickname: false,
+    canUpdateStatusMessage: false,
+    handleNicknameSubmit,
+    handleStatusMessageSubmit,
+    hasProfile: true,
+    isMeError: false,
+    isMeLoading: false,
+    isUpdatingProfile: false,
+    me: {
+      nickname: "민지",
+      profileImageUrl: null,
+      slug: "minji",
+    },
+    nickname: "민지",
+    profileImageSrc: "/images/default-profile.png",
+    statusMessage: "",
+    successMessage: null,
+    updateError: null,
+    updateNicknameDraft: vi.fn(),
+    updateStatusMessageDraft: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useProfileSettingsForm>);
+}
 
 describe("설정 칭호 목록", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useProfileSettingsForm).mockReturnValue({
-      canUpdateProfile: false,
-      handleProfileSubmit: vi.fn(),
-      hasProfile: true,
-      isMeError: false,
-      isMeLoading: false,
-      isUpdatingProfile: false,
-      me: {
-        nickname: "민지",
-        profileImageUrl: null,
-        representativeBadge: {
-          badgeCode: "ROOM_CREATE_00001",
-          name: "방 팠음",
-        },
-        slug: "minji",
-      },
-      nickname: "민지",
-      profileImageSrc: "/images/default-profile.png",
-      statusMessage: "",
-      successMessage: null,
-      updateError: null,
-      updateNicknameDraft: vi.fn(),
-      updateStatusMessageDraft: vi.fn(),
-    } as ReturnType<typeof useProfileSettingsForm>);
-    vi.mocked(useBadgeCatalog).mockReturnValue({
+    mockProfileForm();
+    vi.mocked(useMyBadges).mockReturnValue({
       data: {
         badges: [
           {
-            acquired: false,
-            acquisitionHint: "방을 더 만들어 보세요.",
-            active: true,
-            badgeCode: "ROOM_CREATE_00010",
-            category: "ROOM_CREATION",
-            description: "누적 방 생성 10회 달성",
-            name: "방 열 번 팠음",
-            tier: "TIER_2",
-          },
-          {
             acquired: true,
-            acquisitionHint: "방을 생성해 보세요.",
-            active: true,
+            acquiredAt: "2026-06-19T10:00:00.000Z",
             badgeCode: "ROOM_CREATE_00001",
             category: "ROOM_CREATION",
             description: "누적 방 생성 1회 달성",
             name: "방 팠음",
-            tier: "TIER_1",
+            representative: true,
           },
           {
             acquired: true,
-            acquisitionHint: "방을 두 번 생성해 보세요.",
-            active: true,
+            acquiredAt: "2026-06-20T10:00:00.000Z",
             badgeCode: "ROOM_CREATE_00002",
             category: "ROOM_CREATION",
             description: "누적 방 생성 2회 달성",
             name: "방 또 팠음",
-            tier: "TIER_1",
+            representative: false,
           },
         ],
+        representativeBadge: {
+          badgeCode: "ROOM_CREATE_00001",
+          name: "방 팠음",
+        },
       },
       isError: false,
       isLoading: false,
-    } as ReturnType<typeof useBadgeCatalog>);
+    } as ReturnType<typeof useMyBadges>);
     vi.mocked(useSetRepresentativeBadge).mockReturnValue({
       error: null,
       isPending: false,
@@ -96,7 +95,7 @@ describe("설정 칭호 목록", () => {
     } as unknown as ReturnType<typeof useSetRepresentativeBadge>);
   });
 
-  it("카탈로그 acquired 값으로 선택 가능 여부를 정하고 현재 대표 칭호를 표시한다", () => {
+  it("내가 획득한 칭호만 선택지로 표시하고 현재 대표 칭호를 선택한다", () => {
     render(<ProfileSettingsTab />);
 
     const select = screen.getByRole("combobox", { name: "칭호" });
@@ -107,12 +106,9 @@ describe("설정 칭호 목록", () => {
       "대표 칭호 선택",
       "방 팠음",
       "방 또 팠음",
-      "방 열 번 팠음",
     ]);
     expect(screen.getByRole("option", { name: "방 팠음" })).toBeEnabled();
-    expect(
-      screen.getByRole("option", { name: "방 열 번 팠음" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("option", { name: "방 또 팠음" })).toBeEnabled();
   });
 
   it("획득한 칭호를 선택하면 badgeCode만 대표 칭호 mutation에 전달한다", async () => {
@@ -125,5 +121,17 @@ describe("설정 칭호 목록", () => {
     );
 
     expect(mutate).toHaveBeenCalledWith({ badgeCode: "ROOM_CREATE_00002" });
+  });
+
+  it("한 줄 메시지가 바뀌면 해당 행의 수정 버튼만 활성화한다", () => {
+    mockProfileForm({ canUpdateStatusMessage: true });
+    render(<ProfileSettingsTab />);
+
+    expect(
+      screen.getByRole("button", { name: "사용자 이름 수정" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "한 줄 메시지 수정" }),
+    ).toBeEnabled();
   });
 });

--- a/src/features/settings/ui/ProfileSettingsTab.tsx
+++ b/src/features/settings/ui/ProfileSettingsTab.tsx
@@ -2,15 +2,8 @@
 
 import { useMemo } from "react";
 import Image from "next/image";
-import {
-  getBadgeCatalogItems,
-  getBadgeCode,
-  getRepresentativeBadge,
-  getUserBadgeItems,
-  isCatalogBadgeAcquired,
-} from "@/src/features/badge/model/badgeDisplay";
+import { getBadgeCatalogItems } from "@/src/features/badge/model/badgeDisplay";
 import { useBadgeCatalog } from "@/src/features/badge/hooks/useBadgeCatalog";
-import { useMyBadges } from "@/src/features/badge/hooks/useMyBadges";
 import { useSetRepresentativeBadge } from "@/src/features/badge/hooks/useSetRepresentativeBadge";
 import { useProfileSettingsForm } from "../hooks/useProfileSettingsForm";
 import ProfileSettingsForm from "./components/ProfileSettingsForm";
@@ -20,24 +13,18 @@ import styles from "./ProfileSettingsTab.module.css";
 export default function ProfileSettingsTab() {
   const form = useProfileSettingsForm();
   const catalogQuery = useBadgeCatalog();
-  const myBadgesQuery = useMyBadges(Boolean(form.me));
   const setRepresentativeBadge = useSetRepresentativeBadge();
   const catalogItems = useMemo(
     () => (catalogQuery.data ? getBadgeCatalogItems(catalogQuery.data) : []),
     [catalogQuery.data],
   );
-  const acquiredBadgeCodes = useMemo(() => {
-    const badgeCodes = getUserBadgeItems(myBadgesQuery.data).map(getBadgeCode);
-
-    return new Set(badgeCodes);
-  }, [myBadgesQuery.data]);
   const badgeOptions = useMemo(
     () =>
       catalogItems
         .map((badge, index) => ({
           index,
           badgeCode: badge.badgeCode,
-          isAcquired: isCatalogBadgeAcquired(badge, acquiredBadgeCodes),
+          isAcquired: badge.acquired,
           name: badge.name,
         }))
         .sort((left, right) => {
@@ -47,16 +34,16 @@ export default function ProfileSettingsTab() {
 
           return left.isAcquired ? -1 : 1;
         }),
-    [acquiredBadgeCodes, catalogItems],
+    [catalogItems],
   );
-  const representativeBadge = getRepresentativeBadge(myBadgesQuery.data);
-  const isBadgeLoading = catalogQuery.isLoading || myBadgesQuery.isLoading;
+  const representativeBadge = form.me?.representativeBadge ?? null;
+  const isBadgeLoading = catalogQuery.isLoading;
   const badgeStatusMessage = (() => {
     if (isBadgeLoading) {
       return "칭호 불러오는 중";
     }
 
-    if (catalogQuery.isError || myBadgesQuery.isError) {
+    if (catalogQuery.isError) {
       return "칭호를 불러오지 못했습니다.";
     }
 
@@ -112,7 +99,6 @@ export default function ProfileSettingsTab() {
             !form.me ||
             isBadgeLoading ||
             catalogQuery.isError ||
-            myBadgesQuery.isError ||
             setRepresentativeBadge.isPending ||
             badgeOptions.length === 0
           }
@@ -120,9 +106,7 @@ export default function ProfileSettingsTab() {
           badgeStatusMessage={badgeStatusMessage}
           badgeValue={representativeBadge?.badgeCode ?? ""}
           isBadgeStatusError={Boolean(
-            catalogQuery.isError ||
-              myBadgesQuery.isError ||
-              setRepresentativeBadge.error,
+            catalogQuery.isError || setRepresentativeBadge.error,
           )}
           onBadgeChange={(badgeCode) => {
             if (

--- a/src/features/settings/ui/ProfileSettingsTab.tsx
+++ b/src/features/settings/ui/ProfileSettingsTab.tsx
@@ -2,8 +2,11 @@
 
 import { useMemo } from "react";
 import Image from "next/image";
-import { getBadgeCatalogItems } from "@/src/features/badge/model/badgeDisplay";
-import { useBadgeCatalog } from "@/src/features/badge/hooks/useBadgeCatalog";
+import {
+  getRepresentativeBadge,
+  getUserBadgeItems,
+} from "@/src/features/badge/model/badgeDisplay";
+import { useMyBadges } from "@/src/features/badge/hooks/useMyBadges";
 import { useSetRepresentativeBadge } from "@/src/features/badge/hooks/useSetRepresentativeBadge";
 import { useProfileSettingsForm } from "../hooks/useProfileSettingsForm";
 import ProfileSettingsForm from "./components/ProfileSettingsForm";
@@ -12,38 +15,24 @@ import styles from "./ProfileSettingsTab.module.css";
 
 export default function ProfileSettingsTab() {
   const form = useProfileSettingsForm();
-  const catalogQuery = useBadgeCatalog();
+  const myBadgesQuery = useMyBadges(Boolean(form.me));
   const setRepresentativeBadge = useSetRepresentativeBadge();
-  const catalogItems = useMemo(
-    () => (catalogQuery.data ? getBadgeCatalogItems(catalogQuery.data) : []),
-    [catalogQuery.data],
-  );
   const badgeOptions = useMemo(
     () =>
-      catalogItems
-        .map((badge, index) => ({
-          index,
-          badgeCode: badge.badgeCode,
-          isAcquired: badge.acquired,
-          name: badge.name,
-        }))
-        .sort((left, right) => {
-          if (left.isAcquired === right.isAcquired) {
-            return left.index - right.index;
-          }
-
-          return left.isAcquired ? -1 : 1;
-        }),
-    [catalogItems],
+      getUserBadgeItems(myBadgesQuery.data).map((badge) => ({
+        badgeCode: badge.badgeCode,
+        name: badge.name,
+      })),
+    [myBadgesQuery.data],
   );
-  const representativeBadge = form.me?.representativeBadge ?? null;
-  const isBadgeLoading = catalogQuery.isLoading;
+  const representativeBadge = getRepresentativeBadge(myBadgesQuery.data);
+  const isBadgeLoading = myBadgesQuery.isLoading;
   const badgeStatusMessage = (() => {
     if (isBadgeLoading) {
       return "칭호 불러오는 중";
     }
 
-    if (catalogQuery.isError) {
+    if (myBadgesQuery.isError) {
       return "칭호를 불러오지 못했습니다.";
     }
 
@@ -86,7 +75,8 @@ export default function ProfileSettingsTab() {
           </p>
         </div>
         <ProfileSettingsForm
-          canUpdateProfile={form.canUpdateProfile}
+          canUpdateNickname={form.canUpdateNickname}
+          canUpdateStatusMessage={form.canUpdateStatusMessage}
           hasProfile={form.hasProfile}
           isMeError={form.isMeError}
           isMeLoading={form.isMeLoading}
@@ -98,7 +88,7 @@ export default function ProfileSettingsTab() {
           badgeDisabled={
             !form.me ||
             isBadgeLoading ||
-            catalogQuery.isError ||
+            myBadgesQuery.isError ||
             setRepresentativeBadge.isPending ||
             badgeOptions.length === 0
           }
@@ -106,7 +96,7 @@ export default function ProfileSettingsTab() {
           badgeStatusMessage={badgeStatusMessage}
           badgeValue={representativeBadge?.badgeCode ?? ""}
           isBadgeStatusError={Boolean(
-            catalogQuery.isError || setRepresentativeBadge.error,
+            myBadgesQuery.isError || setRepresentativeBadge.error,
           )}
           onBadgeChange={(badgeCode) => {
             if (
@@ -119,8 +109,9 @@ export default function ProfileSettingsTab() {
             setRepresentativeBadge.mutate({ badgeCode });
           }}
           onNicknameChange={form.updateNicknameDraft}
+          onNicknameSubmit={form.handleNicknameSubmit}
           onStatusMessageChange={form.updateStatusMessageDraft}
-          onSubmit={form.handleProfileSubmit}
+          onStatusMessageSubmit={form.handleStatusMessageSubmit}
         />
       </div>
       <ProfileStats

--- a/src/features/settings/ui/components/ProfileSettingsForm.tsx
+++ b/src/features/settings/ui/components/ProfileSettingsForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { FormEvent } from "react";
+import type { FormEvent, KeyboardEvent } from "react";
 import type { ApiError } from "@/src/shared/api/api-error";
 import styles from "../ProfileSettingsTab.module.css";
 
@@ -8,12 +8,12 @@ type ProfileSettingsFormProps = {
   badgeDisabled: boolean;
   badgeOptions: Array<{
     badgeCode: string;
-    isAcquired: boolean;
     name: string;
   }>;
   badgeStatusMessage: string | null;
   badgeValue: string;
-  canUpdateProfile: boolean;
+  canUpdateNickname: boolean;
+  canUpdateStatusMessage: boolean;
   hasProfile: boolean;
   isBadgeStatusError: boolean;
   isMeError: boolean;
@@ -25,16 +25,27 @@ type ProfileSettingsFormProps = {
   updateError: ApiError | null;
   onBadgeChange: (badgeCode: string) => void;
   onNicknameChange: (value: string) => void;
+  onNicknameSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onStatusMessageChange: (value: string) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onStatusMessageSubmit: (event: FormEvent<HTMLFormElement>) => void;
 };
+
+function preventSubmitWhileComposing(event: KeyboardEvent<HTMLInputElement>) {
+  if (
+    event.key === "Enter" &&
+    (event.nativeEvent.isComposing || event.keyCode === 229)
+  ) {
+    event.preventDefault();
+  }
+}
 
 export default function ProfileSettingsForm({
   badgeDisabled,
   badgeOptions,
   badgeStatusMessage,
   badgeValue,
-  canUpdateProfile,
+  canUpdateNickname,
+  canUpdateStatusMessage,
   hasProfile,
   isBadgeStatusError,
   isMeError,
@@ -46,8 +57,9 @@ export default function ProfileSettingsForm({
   updateError,
   onBadgeChange,
   onNicknameChange,
+  onNicknameSubmit,
   onStatusMessageChange,
-  onSubmit,
+  onStatusMessageSubmit,
 }: ProfileSettingsFormProps) {
   const nicknameInputValue = isMeLoading
     ? "프로필 확인 중"
@@ -56,48 +68,63 @@ export default function ProfileSettingsForm({
       : "로그인이 필요합니다";
 
   return (
-    <form className={styles.profileForm} onSubmit={onSubmit}>
-      <div className={styles.formRow}>
+    <div className={styles.profileForm}>
+      <form className={styles.formRow} onSubmit={onNicknameSubmit}>
         <label className={styles.fieldLabel} htmlFor="settings-nickname">
           사용자 이름
         </label>
-        <div className={styles.nicknameControl}>
+        <div className={styles.editableControl}>
           <input
             id="settings-nickname"
             className={styles.textInput}
             value={nicknameInputValue}
             onChange={(event) => onNicknameChange(event.target.value)}
+            onKeyDown={preventSubmitWhileComposing}
             placeholder="사용자 이름"
+            minLength={2}
+            maxLength={20}
             disabled={!hasProfile || isUpdatingProfile || isMeLoading}
             autoComplete="nickname"
           />
           <button
             type="submit"
             className={styles.primaryButton}
-            disabled={!canUpdateProfile}
+            disabled={!canUpdateNickname}
+            aria-label="사용자 이름 수정"
           >
-            {isUpdatingProfile ? "변경 중" : "저장"}
+            {isUpdatingProfile ? "변경 중" : "수정"}
           </button>
         </div>
-      </div>
-      <div className={styles.formRow}>
+      </form>
+      <form className={styles.formRow} onSubmit={onStatusMessageSubmit}>
         <label className={styles.fieldLabel} htmlFor="settings-status-message">
           한 줄 메시지
         </label>
-        <input
-          id="settings-status-message"
-          className={styles.textInput}
-          value={isMeLoading ? "" : statusMessage}
-          onChange={(event) => onStatusMessageChange(event.target.value)}
-          placeholder="한 줄 메시지를 입력하세요"
-          maxLength={255}
-          disabled={!hasProfile || isUpdatingProfile || isMeLoading}
-          aria-describedby="settings-status-message-hint"
-        />
+        <div className={styles.editableControl}>
+          <input
+            id="settings-status-message"
+            className={styles.textInput}
+            value={isMeLoading ? "" : statusMessage}
+            onChange={(event) => onStatusMessageChange(event.target.value)}
+            onKeyDown={preventSubmitWhileComposing}
+            placeholder="한 줄 메시지를 입력하세요"
+            maxLength={255}
+            disabled={!hasProfile || isUpdatingProfile || isMeLoading}
+            aria-describedby="settings-status-message-hint"
+          />
+          <button
+            type="submit"
+            className={styles.primaryButton}
+            disabled={!canUpdateStatusMessage}
+            aria-label="한 줄 메시지 수정"
+          >
+            {isUpdatingProfile ? "변경 중" : "수정"}
+          </button>
+        </div>
         <span id="settings-status-message-hint" className={styles.srOnly}>
           최대 255자, 빈 문자열로 저장하면 삭제됩니다.
         </span>
-      </div>
+      </form>
       <div className={styles.formRow}>
         <span className={styles.fieldLabel}>최애 곡</span>
         <div className={styles.readonlyField}>개발중입니다.</div>
@@ -121,13 +148,7 @@ export default function ProfileSettingsForm({
               <option
                 key={badge.badgeCode}
                 value={badge.badgeCode}
-                disabled={!badge.isAcquired}
-                className={
-                  badge.isAcquired
-                    ? styles.badgeOptionOwned
-                    : styles.badgeOptionLocked
-                }
-                data-owned={badge.isAcquired}
+                className={styles.badgeOptionOwned}
               >
                 {badge.name}
               </option>
@@ -157,6 +178,6 @@ export default function ProfileSettingsForm({
       {isMeError ? (
         <p className={styles.errorText}>로그인 정보를 확인하지 못했습니다.</p>
       ) : null}
-    </form>
+    </div>
   );
 }

--- a/src/features/user/profile/api/updateMe.test.ts
+++ b/src/features/user/profile/api/updateMe.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { axiosInstance } from "@/src/shared/api/axiosInstance";
+import { updateMe } from "./updateMe";
+
+vi.mock("@/src/shared/api/axiosInstance", () => ({
+  axiosInstance: {
+    patch: vi.fn(),
+  },
+}));
+
+describe("내 프로필 수정 API 계약", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("필수 nickname과 의도한 statusMessage를 보내고 boolean 결과를 반환한다", async () => {
+    vi.mocked(axiosInstance.patch).mockResolvedValue({
+      data: { result: true },
+    });
+
+    await expect(
+      updateMe({ nickname: "민지", statusMessage: "좋은 음악과 함께" }),
+    ).resolves.toBe(true);
+    expect(axiosInstance.patch).toHaveBeenCalledWith(
+      "/api/v1/user-profiles/me",
+      { nickname: "민지", statusMessage: "좋은 음악과 함께" },
+    );
+  });
+});

--- a/src/features/user/profile/api/updateMe.ts
+++ b/src/features/user/profile/api/updateMe.ts
@@ -1,13 +1,13 @@
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
-import type { User } from "@/src/features/user/model/types";
 import type { UpdateMePayload } from "../model/types";
 import { unwrapApiResponse } from "@/src/shared/api/api-response";
-import { ApiResponse } from "@/src/shared/api/types";
+import type { ApiResponse } from "@/src/shared/api/types";
 
-export async function updateMe(payload: UpdateMePayload): Promise<User> {
-  const { data } = await axiosInstance.patch<ApiResponse<User>>(
+export async function updateMe(payload: UpdateMePayload): Promise<boolean> {
+  const { data } = await axiosInstance.patch<ApiResponse<boolean>>(
     "/api/v1/user-profiles/me",
-    payload
+    payload,
   );
+
   return unwrapApiResponse(data);
 }

--- a/src/features/user/profile/hooks/useUpdateMe.test.tsx
+++ b/src/features/user/profile/hooks/useUpdateMe.test.tsx
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { userKeys } from "@/src/features/user/model/queryKeys";
+import type { User } from "@/src/features/user/model/types";
+import { updateMe } from "../api/updateMe";
+import { useUpdateMe } from "./useUpdateMe";
+
+vi.mock("../api/updateMe", () => ({
+  updateMe: vi.fn(),
+}));
+
+describe("useUpdateMe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("성공 시 내 정보와 내 공개 프로필 캐시를 함께 무효화한다", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const me: User = {
+      nickname: "민지",
+      profileImageUrl: null,
+      slug: "minji",
+      statusMessage: "기존 메시지",
+    };
+    queryClient.setQueryData(userKeys.me(), me);
+    queryClient.setQueryData(userKeys.profile(me.slug), me);
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    vi.mocked(updateMe).mockResolvedValue(true);
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useUpdateMe(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        nickname: "민지",
+        statusMessage: "새 메시지",
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: userKeys.me(),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: userKeys.profile("minji"),
+    });
+    expect(queryClient.getQueryData(userKeys.me())).not.toBe(true);
+  });
+});

--- a/src/features/user/profile/hooks/useUpdateMe.ts
+++ b/src/features/user/profile/hooks/useUpdateMe.ts
@@ -10,11 +10,17 @@ import { userKeys } from "@/src/features/user/model/queryKeys";
 export function useUpdateMe() {
   const qc = useQueryClient();
 
-  return useMutation<User, ApiError, UpdateMePayload>({
+  return useMutation<boolean, ApiError, UpdateMePayload>({
     mutationFn: (payload) => updateMe(payload),
-    onSuccess: async (updatedUser) => {
-      qc.setQueryData(userKeys.me(), updatedUser);
-      await qc.invalidateQueries({ queryKey: userKeys.me() });
+    onSuccess: async () => {
+      const me = qc.getQueryData<User | null>(userKeys.me());
+
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: userKeys.me() }),
+        me?.slug
+          ? qc.invalidateQueries({ queryKey: userKeys.profile(me.slug) })
+          : Promise.resolve(),
+      ]);
     },
   });
 }

--- a/src/features/user/profile/model/types.ts
+++ b/src/features/user/profile/model/types.ts
@@ -1,9 +1,8 @@
 import type { BadgeSummary } from "@/src/features/badge/model/types";
 
 export type UpdateMePayload = {
-  nickname?: string;
-  profileImageUrl?: string | null;
-  statusMessage?: string;
+  nickname: string;
+  statusMessage?: string | null;
 };
 
 export type UserProfile = {


### PR DESCRIPTION
## 변경 내용

- 설정 페이지의 칭호 목록과 대표 칭호를 `GET /api/v1/users/me/badges` 응답으로 구성합니다.
- 프로필 수정의 필수 `nickname`, 선택 `statusMessage`, boolean 응답 계약을 반영합니다.
- 닉네임과 한 줄 메시지를 각각 오른쪽 `수정` 버튼으로 독립 저장합니다.
- 프로필/로그아웃 시 공개 프로필과 계정별 칭호 캐시를 안전하게 정리합니다.
- 향후 개발 기본 브랜치를 공유 `dev`로 사용하는 저장소 규칙을 기록합니다.

## 변경 이유

- 설정의 대표 칭호 선택지는 공개 카탈로그가 아니라 현재 사용자가 획득한 칭호만 사용해야 합니다.
- 기존 클라이언트는 boolean 응답을 사용자 객체로 간주해 성공 후 사용자 캐시를 오염시킬 수 있었습니다.
- 한 줄 메시지 저장 시 필수 nickname 누락 및 다른 입력 draft 초기화를 방지해야 합니다.
- 사용자 전환 시 이전 계정의 획득 칭호 캐시가 잠깐 노출되지 않아야 합니다.

## 영향 범위

- [x] UI / 사용자 흐름
- [x] API 요청·응답 계약
- [x] React Query 캐시
- [ ] WebSocket / 실시간 상태
- [x] 인증 / 보안
- [x] 문서 / 개발 도구

## 검증

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [ ] 관련 수동 시나리오 확인
- [x] 실패·로딩·빈 상태 확인

검증 결과 및 재현 방법:

- targeted Vitest: 6 files / 14 tests pass
- full Vitest: 46 files / 108 tests pass
- lint/build/diff-check pass
- fresh read-only QA: pass

## 리뷰 포인트

- 설정 칭호 옵션은 `useMyBadges` 결과만 사용하고 대표 선택값도 같은 응답에서 읽습니다.
- status-only 저장은 현재 서버 nickname을 포함하고 미저장 nickname draft를 보존합니다.
- 프로필 수정 성공 시 `me`와 공개 프로필 캐시를 재검증하며 boolean 응답을 캐시하지 않습니다.
- 로그아웃 성공 시 `badgeKeys.me()`를 제거합니다.

## 기능별 커밋

- `6fb44b0 feat(settings): 칭호 목록을 카탈로그 API 기준으로 전환`
- `e25bb70 fix(settings): 칭호와 프로필 수정 계약 정정`
- `0524085 docs(agent): dev 브랜치 작업 정책 기록`

## 위험 및 후속 작업

- 실제 로그인 브라우저에서 획득 칭호 조회, 대표 칭호 변경, 닉네임/한 줄 메시지 독립 저장 수동 QA는 미실시했습니다.
- 원격 `dev` 브랜치는 아직 없으며 다음 개발 시작 시 최신 원격 기본 브랜치에서 최초 생성합니다.

## 추적 정보

- Linked issue: 없음
- Execution plan: `docs/exec-plans/active/2026-08-04-settings-badge-catalog/`
- Selected skills: `queuing-pr-review-cycle`, `queuing-api-boundary`, `queuing-ui-flow`, `frontend-architecture-guardrails`, `queuing-qa-reviewer`
- QA result: `pass`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 설정에서 닉네임과 한 줄 메시지를 각각 독립적으로 수정할 수 있습니다.
  - 닉네임은 2~20자 범위로 입력할 수 있습니다.
  - 대표 칭호를 보유한 칭호 목록에서 선택할 수 있습니다.
  - 칭호 및 프로필 변경 후 관련 정보가 자동으로 갱신됩니다.

- **버그 수정**
  - 로그아웃 후 이전 사용자의 칭호 정보가 남아 보일 수 있는 문제를 수정했습니다.
  - 프로필 수정 시 닉네임과 한 줄 메시지의 임시 입력값이 서로 영향을 주지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->