### PR TITLE
fix(discovery): CREATE·FOLLOW·SETTING 첫 클릭 로딩 제거

### DIFF
--- a/docs/exec-plans/active/2026-08-10-discovery-modal-preload/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-10-discovery-modal-preload/delivery-state.md
@@ -1,0 +1,12 @@
+# Delivery State
+
+- status: ci-pending
+- branch: `dev`
+- base: `main`
+- issue: none
+- pr: Draft PR #38
+- selected_skills: feature-delivery, ui-flow, frontend-architecture-guardrails, qa-reviewer
+- local_qa: lint pass; 108 files/330 tests pass; build pass; fresh read-only QA pass; in-app browser unavailable
+- ci: pending push
+- review_threads: none
+- next_action: docs commit 후 dev push 및 Draft PR #38 CI 확인

--- a/docs/exec-plans/active/2026-08-10-discovery-modal-preload/plan.md
+++ b/docs/exec-plans/active/2026-08-10-discovery-modal-preload/plan.md
@@ -1,0 +1,39 @@
+# 탐색 메뉴 모달 선로딩
+
+## Scope
+
+- 홈과 검색 화면의 `CREATE`, `FOLLOW`, `SETTING` 모달은 dynamic chunk 분리를 유지한다.
+- 화면 안정화 뒤 idle 시점과 메뉴 항목 hover·focus·pointer intent에서 chunk를 미리 받는다.
+- 클릭 시 해당 chunk가 준비된 뒤 모달 open state를 변경해 전체 화면 loading fallback이 노출되지 않게 한다.
+- 비밀번호 방 입장 모달은 이번 요청 범위에서 제외한다.
+
+## Selected Skills
+
+- `queuing-feature-delivery`
+- `queuing-ui-flow`
+- `frontend-architecture-guardrails`
+- `queuing-qa-reviewer`
+
+## Commit Slice
+
+1. `fix(discovery): 지연 모달 클릭 전 선로딩`
+2. `docs(delivery): 모달 선로딩 검증 기록`
+
+## Acceptance Criteria
+
+- CREATE·FOLLOW·SETTING은 최초 클릭에서도 full-screen loading spinner를 렌더하지 않는다.
+- 세 모달은 홈 초기 JavaScript에 정적 import되지 않는다.
+- idle preload는 지원 브라우저와 fallback timer 양쪽에서 동작하고 unmount 시 예약 작업을 정리한다.
+- 데스크톱 메뉴와 모바일 빠른 메뉴의 hover·focus·pointer intent가 해당 모달만 선로딩한다.
+- preload 실패는 다음 intent/click에서 재시도 가능하다.
+- preload 중에는 다른 discovery 모달 요청을 무시해 둘 이상의 모달이 동시에 열리지 않는다.
+- targeted test, `npm run lint`, `npm run test`, `npm run build`, fresh read-only QA가 통과한다.
+
+## Progress
+
+- [x] 현재 dynamic import와 fallback 원인 확인
+- [x] preload resource·idle scheduler 구현
+- [x] 홈·검색·모바일 intent 연결
+- [x] 회귀 테스트와 전체 검증
+- [x] 기능·테스트 commit
+- [ ] dev push, Draft PR #38 갱신 및 CI 확인

--- a/docs/exec-plans/active/2026-08-10-discovery-modal-preload/qa-report.md
+++ b/docs/exec-plans/active/2026-08-10-discovery-modal-preload/qa-report.md
@@ -1,0 +1,40 @@
+# QA Report
+
+## Result
+
+- status: pass
+- scope: 홈·검색의 CREATE, FOLLOW, SETTING modal chunk preload와 open state
+
+## Automated Verification
+
+- `npm run lint`: pass
+- `npm run test`: pass — 108 files, 330 tests
+- `npm run build`: pass — 8 routes generated
+- `git diff --check`: pass
+
+## Boundary Checks
+
+- CREATE, FOLLOW, SETTING은 정적 import로 합치지 않고 각각 production dynamic chunk로 유지된다.
+- dynamic component fallback은 `null`이며 preload 성공 뒤에만 modal state를 연다.
+- idle preload 실패는 사용자에게 노출하지 않고, 실제 클릭 실패는 `role="alert"` 영역에 표시한다.
+- 실패 promise는 제거되어 같은 액션 재클릭 시 loader를 다시 실행한다.
+- 단일 reservation으로 preload 중 교차 클릭과 열린 modal 위의 추가 요청을 차단한다.
+- 홈·검색 desktop menu, mobile quick menu, 홈/검색 empty-state CREATE 버튼이 hover·focus·pointer intent를 전달한다.
+
+## Production Bundle Evidence
+
+- CREATE loader: runtime module `88140`, separate JS/CSS chunks
+- FOLLOW loader: runtime module `96574`, separate JS/CSS chunks
+- SETTING loader: runtime module `29203`, separate JS/CSS chunks
+- 홈·검색 route chunk에는 위 loader 참조와 `loading: () => null`이 포함되며 modal 구현은 별도 chunk에서 로드된다.
+
+## Manual QA Limitation
+
+- Browser runtime에서 연결 가능한 browser instance가 없어 클릭 smoke test를 자동화하지 못했다.
+- unit/state/UI interaction tests와 production bundle 검증으로 대체했으며, publish 전 fresh read-only QA를 별도로 수행한다.
+
+## Fresh Read-only QA
+
+- result: pass
+- blocker: none
+- 확인 범위: 세 modal open gate, 실패 재시도, 단일 reservation, desktop/mobile/empty-state intent, production chunk 분리, idle cleanup

--- a/docs/exec-plans/active/2026-08-10-discovery-modal-preload/ui-flow.md
+++ b/docs/exec-plans/active/2026-08-10-discovery-modal-preload/ui-flow.md
@@ -1,0 +1,8 @@
+# UI Flow
+
+1. 홈·검색 화면 mount 뒤 브라우저 idle callback에서 CREATE·FOLLOW·SETTING chunk를 낮은 우선순위로 요청한다.
+2. 사용자가 데스크톱 메뉴 항목 또는 모바일 빠른 메뉴 버튼에 hover·focus·pointer intent를 주면 해당 chunk를 즉시 요청한다.
+3. 사용자가 클릭하면 인증을 확인한 뒤 동일 preload promise 완료를 기다린다.
+4. chunk가 준비된 다음에만 modal open state를 변경하므로 page-level loading dialog는 표시하지 않는다.
+5. 첫 요청부터 modal을 닫을 때까지 해당 modal이 discovery modal slot을 예약해 느린 네트워크에서도 다른 modal이 겹쳐 열리지 않게 한다.
+6. 이미 받은 chunk는 promise와 브라우저 module cache를 재사용한다. 실패한 promise는 비워 다음 동작에서 재시도하고, 실제 클릭 실패만 접근 가능한 오류 문구로 표시한다.

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,5 +1,7 @@
 # Active Execution Plans
 
+- [2026-08-10-discovery-modal-preload](./2026-08-10-discovery-modal-preload/plan.md): ready-to-publish — CREATE·FOLLOW·SETTING 지연 모달 클릭 스피너 제거
+
 - [2026-08-09-runtime-audit-remediation](./2026-08-09-runtime-audit-remediation/plan.md): implementing — 프론트 런타임 감사 confirmed finding 후속 최적화
 
 - [2026-08-09-frontend-runtime-audit](./2026-08-09-frontend-runtime-audit/plan.md): ready — 프론트 전 영역 미사용 코드·런타임 성능·구조 병렬 감사 완료, 전달 대기

--- a/src/features/follow/ui/FollowModal.tsx
+++ b/src/features/follow/ui/FollowModal.tsx
@@ -7,7 +7,7 @@ import FollowTabPanel from "./components/FollowTabPanel";
 import FollowTabs from "./components/FollowTabs";
 import styles from "./FollowModal.module.css";
 
-type FollowModalProps = {
+export type FollowModalProps = {
   open: boolean;
   onClose: () => void;
 };

--- a/src/features/home/ui/HomeScreen.tsx
+++ b/src/features/home/ui/HomeScreen.tsx
@@ -22,6 +22,7 @@ import {
   getSelectedHomeGenreTags,
   type HomeFilterKey,
   type HomeFilterOption,
+  type HomeMenuItem,
 } from "@/src/features/room/discovery/ui/HomeControlPanelShell";
 import HomeTopBar from "./HomeTopBar";
 import HomeSearchControlDock from "@/src/features/room/discovery/ui/HomeSearchControlDock";
@@ -33,14 +34,14 @@ import AuthRequiredModal from "@/src/shared/ui/auth-required/AuthRequiredModal";
 import { mergeRoomMeta } from "@/src/features/room/model/mergeRoomMeta";
 import styles from "./HomeScreen.module.css";
 import LazyModalFallback from "@/src/shared/ui/lazy-modal-fallback/LazyModalFallback";
+import { useIdlePreload } from "@/src/shared/lib/useIdlePreload";
+import {
+  DISCOVERY_MODAL_PRELOADERS,
+  discoveryModalResources,
+  preloadDiscoveryModalForMenuItem,
+} from "@/src/features/room/discovery/lib/discoveryModalResources";
+import { useDiscoveryModalController } from "@/src/features/room/discovery/model/useDiscoveryModalController";
 
-const RoomFormModal = dynamic(
-  () => import("@/src/features/room/create/ui/RoomFormModal"),
-  {
-    ssr: false,
-    loading: () => <LazyModalFallback label="방 만들기 화면 로딩 중" />,
-  },
-);
 const RoomJoinPasswordModal = dynamic(
   () => import("@/src/features/room/join/ui/RoomJoinPasswordModal"),
   {
@@ -48,29 +49,18 @@ const RoomJoinPasswordModal = dynamic(
     loading: () => <LazyModalFallback label="방 입장 화면 로딩 중" />,
   },
 );
-const FollowModal = dynamic(
-  () => import("@/src/features/follow/ui/FollowModal"),
-  {
-    ssr: false,
-    loading: () => <LazyModalFallback label="친구 화면 로딩 중" />,
-  },
-);
-const SettingsModal = dynamic(
-  () => import("@/src/features/settings/ui/SettingsModal"),
-  {
-    ssr: false,
-    loading: () => <LazyModalFallback label="설정 화면 로딩 중" />,
-  },
-);
+const RoomFormModal = discoveryModalResources.create.Component;
+const FollowModal = discoveryModalResources.follow.Component;
+const SettingsModal = discoveryModalResources.settings.Component;
 
 export default function HomeScreen() {
+  useIdlePreload(DISCOVERY_MODAL_PRELOADERS);
+
   const isMobileLayout = useMediaQuery("(max-width: 760px)");
   const [roomListFilters, setRoomListFilters] =
     useState(DEFAULT_HOME_FILTERS);
   const [mobileSearchQuery, setMobileSearchQuery] = useState("");
-  const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false);
-  const [isFollowModalOpen, setIsFollowModalOpen] = useState(false);
-  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const discoveryModal = useDiscoveryModalController();
   const {
     authRequiredDescription,
     closeAuthRequiredModal,
@@ -102,27 +92,28 @@ export default function HomeScreen() {
     ],
   );
 
-  const requestCreateRoom = () =>
+  const requestCreateRoom = () => {
     requestAuthenticatedAction({
       description: "방 만들기는 로그인 후 이용할 수 있어요.",
-      onAuthenticated: () => setIsCreateRoomModalOpen(true),
+      onAuthenticated: () => discoveryModal.requestModal("create"),
     });
+  };
 
-  const requestOpenFollow = () =>
+  const requestOpenFollow = () => {
     requestAuthenticatedAction({
       description: "팔로우 기능은 로그인 후 이용할 수 있어요.",
-      onAuthenticated: () => setIsFollowModalOpen(true),
+      onAuthenticated: () => discoveryModal.requestModal("follow"),
     });
+  };
 
-  const requestOpenSettings = () =>
+  const requestOpenSettings = () => {
     requestAuthenticatedAction({
       description: "설정은 로그인 후 이용할 수 있어요.",
-      onAuthenticated: () => setIsSettingsModalOpen(true),
+      onAuthenticated: () => discoveryModal.requestModal("settings"),
     });
+  };
   const hasPageModalOpen =
-    isCreateRoomModalOpen ||
-    isFollowModalOpen ||
-    isSettingsModalOpen ||
+    Boolean(discoveryModal.activeModal) ||
     isAuthRequiredModalOpen;
 
   return (
@@ -131,25 +122,27 @@ export default function HomeScreen() {
         activeFilters={roomListFilters}
         hasPageModalOpen={hasPageModalOpen}
         isMobileLayout={isMobileLayout}
+        modalLoadErrorMessage={discoveryModal.loadErrorMessage}
         onCreateRoom={requestCreateRoom}
         onMobileSearchQueryChange={setMobileSearchQuery}
+        onMenuItemIntent={preloadDiscoveryModalForMenuItem}
         onOpenFollow={requestOpenFollow}
         onOpenSettings={requestOpenSettings}
         onSelectFilter={selectRoomListFilter}
         roomsQueryParams={roomListQueryParams}
       />
-      {isCreateRoomModalOpen ? (
+      {discoveryModal.activeModal === "create" ? (
         <RoomFormModal
           open
           mode="create"
-          onClose={() => setIsCreateRoomModalOpen(false)}
+          onClose={discoveryModal.closeModal}
         />
       ) : null}
-      {isFollowModalOpen ? (
-        <FollowModal open onClose={() => setIsFollowModalOpen(false)} />
+      {discoveryModal.activeModal === "follow" ? (
+        <FollowModal open onClose={discoveryModal.closeModal} />
       ) : null}
-      {isSettingsModalOpen ? (
-        <SettingsModal open onClose={() => setIsSettingsModalOpen(false)} />
+      {discoveryModal.activeModal === "settings" ? (
+        <SettingsModal open onClose={discoveryModal.closeModal} />
       ) : null}
       <AuthRequiredModal
         open={isAuthRequiredModalOpen}
@@ -165,8 +158,10 @@ type HomeRoomsContentProps = {
   activeFilters: typeof DEFAULT_HOME_FILTERS;
   hasPageModalOpen: boolean;
   isMobileLayout: boolean;
+  modalLoadErrorMessage: string | null;
   onCreateRoom: () => void;
   onMobileSearchQueryChange: (query: string) => void;
+  onMenuItemIntent: (menuItem: HomeMenuItem) => void;
   onOpenFollow: () => void;
   onOpenSettings: () => void;
   onSelectFilter: (key: HomeFilterKey, option: HomeFilterOption) => void;
@@ -177,8 +172,10 @@ function HomeRoomsContent({
   activeFilters,
   hasPageModalOpen,
   isMobileLayout,
+  modalLoadErrorMessage,
   onCreateRoom,
   onMobileSearchQueryChange,
+  onMenuItemIntent,
   onOpenFollow,
   onOpenSettings,
   onSelectFilter,
@@ -221,6 +218,8 @@ function HomeRoomsContent({
     onSelectRoom: setCurrentRoomSlug,
   });
   const randomEntry = useRandomEntryNavigation();
+  const actionErrorMessage =
+    modalLoadErrorMessage ?? randomEntry.errorMessage;
   const isChromeReduced = hasPageModalOpen || Boolean(roomEntry.passwordRoom);
   const roomMetaQuery = useRoomMetaQuery(
     !isChromeReduced ? selectedRoomSlug : null,
@@ -257,6 +256,7 @@ function HomeRoomsContent({
       {isMobileLayout && !isChromeReduced ? (
         <MobileHomeRoomFeed
           activeFilters={activeFilters}
+          actionErrorMessage={actionErrorMessage}
           errorMessage={roomListErrorMessage}
           genreOptions={genreOptions}
           hasNextPage={Boolean(roomsQuery.hasNextPage)}
@@ -267,6 +267,7 @@ function HomeRoomsContent({
           onLoadMoreRooms={() => {
             void roomsQuery.fetchNextPage();
           }}
+          onMenuItemIntent={onMenuItemIntent}
           onOpenFollow={onOpenFollow}
           onOpenSettings={onOpenSettings}
           onRandomEntry={randomEntry.requestRandomEntry}
@@ -276,7 +277,6 @@ function HomeRoomsContent({
           onRequestRoomEntry={roomEntry.requestRoomEntry}
           onSelectFilter={onSelectFilter}
           onSelectRoom={setCurrentRoomSlug}
-          randomEntryErrorMessage={randomEntry.errorMessage}
           rooms={visibleRooms}
           selectedRoomSlug={selectedRoomSlug}
         />
@@ -290,6 +290,7 @@ function HomeRoomsContent({
             isLoading={roomsQuery.isPending}
             selectedRoomOwner={roomMetaQuery.data?.owner ?? null}
             onCreateRoom={onCreateRoom}
+            onCreateRoomIntent={() => onMenuItemIntent("CREATE")}
             onSelectRoom={setCurrentRoomSlug}
             onRequestRoomEntry={roomEntry.requestRoomEntry}
             onRetry={() => {
@@ -310,8 +311,9 @@ function HomeRoomsContent({
             onCreateRoom={onCreateRoom}
             onOpenFollow={onOpenFollow}
             onOpenSettings={onOpenSettings}
+            onMenuItemIntent={onMenuItemIntent}
             isRandomEntryPending={randomEntry.isPending}
-            randomEntryErrorMessage={randomEntry.errorMessage}
+            actionErrorMessage={actionErrorMessage}
             onEnterSelectedRoom={() => {
               if (visibleCurrentRoom) {
                 roomEntry.requestRoomEntry(visibleCurrentRoom);

--- a/src/features/home/ui/MobileHomeRoomFeed.test.tsx
+++ b/src/features/home/ui/MobileHomeRoomFeed.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_HOME_FILTERS } from "@/src/features/room/discovery/ui/HomeControlPanelShell";
+import MobileHomeRoomFeed from "./MobileHomeRoomFeed";
+
+describe("MobileHomeRoomFeed 모달 선로딩 intent", () => {
+  it("CREATE, FOLLOW, SETTING intent와 기존 클릭 액션을 함께 전달한다", async () => {
+    const user = userEvent.setup();
+    const onCreateRoom = vi.fn();
+    const onMenuItemIntent = vi.fn();
+    const onOpenFollow = vi.fn();
+    const onOpenSettings = vi.fn();
+
+    render(
+      <MobileHomeRoomFeed
+        activeFilters={DEFAULT_HOME_FILTERS}
+        genreOptions={[{ label: "ALL", value: "ALL" }]}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onCreateRoom={onCreateRoom}
+        onLoadMoreRooms={vi.fn()}
+        onMenuItemIntent={onMenuItemIntent}
+        onOpenFollow={onOpenFollow}
+        onOpenSettings={onOpenSettings}
+        onRandomEntry={vi.fn()}
+        onRequestRoomEntry={vi.fn()}
+        onSelectFilter={vi.fn()}
+        onSelectRoom={vi.fn()}
+        rooms={[]}
+        selectedRoomSlug={null}
+      />,
+    );
+
+    const [createButton, emptyCreateButton] = screen.getAllByRole("button", {
+      name: "방 만들기",
+    });
+    const followButton = screen.getByRole("button", { name: "팔로우" });
+    const settingsButton = screen.getByRole("button", { name: "설정" });
+
+    fireEvent.pointerEnter(createButton);
+    fireEvent.focus(followButton);
+    fireEvent.pointerDown(settingsButton);
+    fireEvent.pointerEnter(emptyCreateButton);
+
+    expect(onMenuItemIntent).toHaveBeenNthCalledWith(1, "CREATE");
+    expect(onMenuItemIntent).toHaveBeenNthCalledWith(2, "FOLLOW");
+    expect(onMenuItemIntent).toHaveBeenNthCalledWith(3, "SETTING");
+    expect(onMenuItemIntent).toHaveBeenNthCalledWith(4, "CREATE");
+
+    await user.click(createButton);
+    await user.click(followButton);
+    await user.click(settingsButton);
+    expect(onCreateRoom).toHaveBeenCalledOnce();
+    expect(onOpenFollow).toHaveBeenCalledOnce();
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/home/ui/MobileHomeRoomFeed.tsx
+++ b/src/features/home/ui/MobileHomeRoomFeed.tsx
@@ -19,6 +19,7 @@ import styles from "./MobileHomeRoomFeed.module.css";
 
 type Props = {
   activeFilters: HomeFilterState;
+  actionErrorMessage?: string | null;
   errorMessage?: string | null;
   genreOptions: HomeGenreFilterOptionDescriptor[];
   hasNextPage: boolean;
@@ -27,6 +28,7 @@ type Props = {
   isRandomEntryPending?: boolean;
   onCreateRoom: () => void;
   onLoadMoreRooms: () => void;
+  onMenuItemIntent: (menuItem: "CREATE" | "FOLLOW" | "SETTING") => void;
   onOpenFollow: () => void;
   onOpenSettings: () => void;
   onRandomEntry: () => void;
@@ -34,7 +36,6 @@ type Props = {
   onRequestRoomEntry: (room: Room) => void;
   onSelectFilter: (key: HomeFilterKey, option: HomeFilterOption) => void;
   onSelectRoom: (roomSlug: string) => void;
-  randomEntryErrorMessage?: string | null;
   rooms: Room[];
   selectedRoomSlug: string | null;
 };
@@ -109,6 +110,7 @@ function MobileHomeRoomCard({
 
 export default function MobileHomeRoomFeed({
   activeFilters,
+  actionErrorMessage = null,
   errorMessage,
   genreOptions,
   hasNextPage,
@@ -117,6 +119,7 @@ export default function MobileHomeRoomFeed({
   isRandomEntryPending = false,
   onCreateRoom,
   onLoadMoreRooms,
+  onMenuItemIntent,
   onOpenFollow,
   onOpenSettings,
   onRandomEntry,
@@ -124,7 +127,6 @@ export default function MobileHomeRoomFeed({
   onRequestRoomEntry,
   onSelectFilter,
   onSelectRoom,
-  randomEntryErrorMessage = null,
   rooms,
   selectedRoomSlug,
 }: Props) {
@@ -147,6 +149,9 @@ export default function MobileHomeRoomFeed({
         <button
           type="button"
           className={styles.primaryAction}
+          onFocus={() => onMenuItemIntent("CREATE")}
+          onPointerDown={() => onMenuItemIntent("CREATE")}
+          onPointerEnter={() => onMenuItemIntent("CREATE")}
           onClick={onCreateRoom}
         >
           방 만들기
@@ -168,6 +173,9 @@ export default function MobileHomeRoomFeed({
         <button
           type="button"
           className={styles.secondaryAction}
+          onFocus={() => onMenuItemIntent("FOLLOW")}
+          onPointerDown={() => onMenuItemIntent("FOLLOW")}
+          onPointerEnter={() => onMenuItemIntent("FOLLOW")}
           onClick={onOpenFollow}
           aria-label="팔로우"
         >
@@ -176,15 +184,18 @@ export default function MobileHomeRoomFeed({
         <button
           type="button"
           className={styles.secondaryAction}
+          onFocus={() => onMenuItemIntent("SETTING")}
+          onPointerDown={() => onMenuItemIntent("SETTING")}
+          onPointerEnter={() => onMenuItemIntent("SETTING")}
           onClick={onOpenSettings}
           aria-label="설정"
         >
           <Settings className={styles.actionIcon} aria-hidden="true" />
         </button>
       </section>
-      {randomEntryErrorMessage ? (
+      {actionErrorMessage ? (
         <p className={styles.quickActionError} role="alert">
-          {randomEntryErrorMessage}
+          {actionErrorMessage}
         </p>
       ) : null}
 
@@ -237,6 +248,9 @@ export default function MobileHomeRoomFeed({
             <button
               type="button"
               className={styles.emptyCreateButton}
+              onFocus={() => onMenuItemIntent("CREATE")}
+              onPointerDown={() => onMenuItemIntent("CREATE")}
+              onPointerEnter={() => onMenuItemIntent("CREATE")}
               onClick={onCreateRoom}
             >
               방 만들기

--- a/src/features/room/create/ui/RoomFormModal.tsx
+++ b/src/features/room/create/ui/RoomFormModal.tsx
@@ -39,7 +39,7 @@ const EMPTY_TAG_SLUGS: string[] = [];
 
 type RoomFormModalMode = "create" | "edit";
 
-type RoomFormModalProps = {
+export type RoomFormModalProps = {
   open: boolean;
   mode: RoomFormModalMode;
   roomSlug?: string;

--- a/src/features/room/discovery/lib/discoveryModalResources.tsx
+++ b/src/features/room/discovery/lib/discoveryModalResources.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { FollowModalProps } from "@/src/features/follow/ui/FollowModal";
+import type { RoomFormModalProps } from "@/src/features/room/create/ui/RoomFormModal";
+import type { SettingsModalProps } from "@/src/features/settings/ui/SettingsModal";
+import type { HomeMenuItem } from "@/src/features/room/discovery/ui/HomeControlPanelShell";
+import {
+  createPreloadableDynamicComponent,
+  requestComponentPreload,
+  type ComponentPreloader,
+} from "@/src/shared/lib/preloadableDynamicComponent";
+
+export type DiscoveryModalKey = "create" | "follow" | "settings";
+
+export const discoveryModalResources = {
+  create: createPreloadableDynamicComponent<RoomFormModalProps>(() =>
+    import("@/src/features/room/create/ui/RoomFormModal"),
+  ),
+  follow: createPreloadableDynamicComponent<FollowModalProps>(() =>
+    import("@/src/features/follow/ui/FollowModal"),
+  ),
+  settings: createPreloadableDynamicComponent<SettingsModalProps>(() =>
+    import("@/src/features/settings/ui/SettingsModal"),
+  ),
+} as const;
+
+export const DISCOVERY_MODAL_PRELOADERS = [
+  discoveryModalResources.create.preload,
+  discoveryModalResources.follow.preload,
+  discoveryModalResources.settings.preload,
+] as const;
+
+const preloaderByMenuItem: Partial<
+  Record<HomeMenuItem, (typeof DISCOVERY_MODAL_PRELOADERS)[number]>
+> = {
+  CREATE: discoveryModalResources.create.preload,
+  FOLLOW: discoveryModalResources.follow.preload,
+  SETTING: discoveryModalResources.settings.preload,
+};
+
+export function getDiscoveryModalPreloader(
+  modalKey: DiscoveryModalKey,
+): ComponentPreloader {
+  return discoveryModalResources[modalKey].preload;
+}
+
+export function preloadDiscoveryModalForMenuItem(item: HomeMenuItem) {
+  const preloader = preloaderByMenuItem[item];
+
+  if (preloader) {
+    requestComponentPreload(preloader);
+  }
+}

--- a/src/features/room/discovery/model/useDiscoveryModalController.test.tsx
+++ b/src/features/room/discovery/model/useDiscoveryModalController.test.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const preloaderByModal = vi.hoisted(() => ({
+  create: vi.fn<() => Promise<unknown>>(),
+  follow: vi.fn<() => Promise<unknown>>(),
+  settings: vi.fn<() => Promise<unknown>>(),
+}));
+
+vi.mock(
+  "@/src/features/room/discovery/lib/discoveryModalResources",
+  () => ({
+    getDiscoveryModalPreloader: (
+      modalKey: keyof typeof preloaderByModal,
+    ) => preloaderByModal[modalKey],
+  }),
+);
+
+import { useDiscoveryModalController } from "./useDiscoveryModalController";
+
+function createDeferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+describe("useDiscoveryModalController", () => {
+  beforeEach(() => {
+    Object.values(preloaderByModal).forEach((preloader) => {
+      preloader.mockReset();
+    });
+  });
+
+  it("선로딩 완료 전에는 모달을 열지 않고 교차 요청도 하나로 제한한다", async () => {
+    const createLoad = createDeferred();
+    preloaderByModal.create.mockReturnValue(createLoad.promise);
+    preloaderByModal.follow.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useDiscoveryModalController());
+
+    act(() => {
+      result.current.requestModal("create");
+      result.current.requestModal("follow");
+    });
+
+    expect(result.current.activeModal).toBeNull();
+    expect(preloaderByModal.create).toHaveBeenCalledOnce();
+    expect(preloaderByModal.follow).not.toHaveBeenCalled();
+
+    await act(async () => {
+      createLoad.resolve();
+      await createLoad.promise;
+    });
+    expect(result.current.activeModal).toBe("create");
+
+    act(() => {
+      result.current.closeModal();
+      result.current.requestModal("follow");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.activeModal).toBe("follow");
+  });
+
+  it("실패 시 화면을 유지하고 같은 액션의 재시도를 허용한다", async () => {
+    preloaderByModal.settings
+      .mockRejectedValueOnce(new Error("chunk failed"))
+      .mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useDiscoveryModalController());
+
+    await act(async () => {
+      result.current.requestModal("settings");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.activeModal).toBeNull();
+    expect(result.current.loadErrorMessage).toBe(
+      "화면을 불러오지 못했어요. 다시 시도해 주세요.",
+    );
+
+    await act(async () => {
+      result.current.requestModal("settings");
+      await Promise.resolve();
+    });
+    expect(preloaderByModal.settings).toHaveBeenCalledTimes(2);
+    expect(result.current.activeModal).toBe("settings");
+    expect(result.current.loadErrorMessage).toBeNull();
+  });
+});

--- a/src/features/room/discovery/model/useDiscoveryModalController.ts
+++ b/src/features/room/discovery/model/useDiscoveryModalController.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import {
+  getDiscoveryModalPreloader,
+  type DiscoveryModalKey,
+} from "@/src/features/room/discovery/lib/discoveryModalResources";
+import { runAfterComponentPreload } from "@/src/shared/lib/preloadableDynamicComponent";
+
+const MODAL_LOAD_ERROR_MESSAGE =
+  "화면을 불러오지 못했어요. 다시 시도해 주세요.";
+
+export function useDiscoveryModalController() {
+  const modalReservationRef = useRef<DiscoveryModalKey | null>(null);
+  const [activeModal, setActiveModal] = useState<DiscoveryModalKey | null>(
+    null,
+  );
+  const [loadErrorMessage, setLoadErrorMessage] = useState<string | null>(null);
+
+  const requestModal = useCallback((modalKey: DiscoveryModalKey) => {
+    if (modalReservationRef.current) {
+      return;
+    }
+
+    modalReservationRef.current = modalKey;
+    setLoadErrorMessage(null);
+
+    runAfterComponentPreload(
+      getDiscoveryModalPreloader(modalKey),
+      () => {
+        if (modalReservationRef.current !== modalKey) {
+          return;
+        }
+
+        setActiveModal(modalKey);
+      },
+      () => {
+        if (modalReservationRef.current !== modalKey) {
+          return;
+        }
+
+        modalReservationRef.current = null;
+        setLoadErrorMessage(MODAL_LOAD_ERROR_MESSAGE);
+      },
+    );
+  }, []);
+
+  const closeModal = useCallback(() => {
+    modalReservationRef.current = null;
+    setActiveModal(null);
+  }, []);
+
+  return {
+    activeModal,
+    closeModal,
+    loadErrorMessage,
+    requestModal,
+  };
+}

--- a/src/features/room/discovery/ui/HomeControlPanelShell.interaction.test.tsx
+++ b/src/features/room/discovery/ui/HomeControlPanelShell.interaction.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import HomeControlPanelShell, { type HomeMenuItem } from "./HomeControlPanelShell";
+
+describe("HomeControlPanelShell 메뉴 선로딩 intent", () => {
+  it.each(["CREATE", "FOLLOW", "SETTING"] as const)(
+    "%s 메뉴의 hover, focus, pointer down을 전달하고 클릭 동작을 유지한다",
+    async (menuItem) => {
+      const user = userEvent.setup();
+      const onMenuItemIntent = vi.fn();
+      const onSelectMenuItem = vi.fn<(item: HomeMenuItem) => void>();
+      render(
+        <HomeControlPanelShell
+          variant="menu"
+          onMenuItemIntent={onMenuItemIntent}
+          onSelectMenuItem={onSelectMenuItem}
+        />,
+      );
+      const button = screen.getByRole("button", { name: menuItem });
+
+      fireEvent.pointerEnter(button);
+      fireEvent.focus(button);
+      fireEvent.pointerDown(button);
+      expect(onMenuItemIntent).toHaveBeenNthCalledWith(1, menuItem);
+      expect(onMenuItemIntent).toHaveBeenNthCalledWith(2, menuItem);
+      expect(onMenuItemIntent).toHaveBeenNthCalledWith(3, menuItem);
+
+      await user.click(button);
+      expect(onSelectMenuItem).toHaveBeenCalledWith(menuItem);
+    },
+  );
+});

--- a/src/features/room/discovery/ui/HomeControlPanelShell.tsx
+++ b/src/features/room/discovery/ui/HomeControlPanelShell.tsx
@@ -20,6 +20,7 @@ type Props =
   | {
       variant: "menu";
       isRandomEntryPending?: boolean;
+      onMenuItemIntent?: (menuItem: HomeMenuItem) => void;
       onSelectMenuItem: (menuItem: HomeMenuItem) => void;
     }
   | {
@@ -239,6 +240,9 @@ export default function HomeControlPanelShell(props: Props) {
                 className={styles.menuItem}
                 disabled={isPendingRandom}
                 aria-busy={isPendingRandom}
+                onFocus={() => props.onMenuItemIntent?.(item)}
+                onPointerDown={() => props.onMenuItemIntent?.(item)}
+                onPointerEnter={() => props.onMenuItemIntent?.(item)}
                 onClick={() => props.onSelectMenuItem(item)}
               >
                 {isPendingRandom ? (

--- a/src/features/room/discovery/ui/HomeSearchControlDock.tsx
+++ b/src/features/room/discovery/ui/HomeSearchControlDock.tsx
@@ -27,11 +27,12 @@ type Props = {
   onRandomEntry: () => void;
   onSelectFilter: (key: HomeFilterKey, option: HomeFilterOption) => void;
   onCreateRoom: () => void;
+  onMenuItemIntent?: (menuItem: HomeMenuItem) => void;
   onOpenFollow: () => void;
   onOpenSettings: () => void;
   onEnterSelectedRoom: () => void;
   isRandomEntryPending?: boolean;
-  randomEntryErrorMessage?: string | null;
+  actionErrorMessage?: string | null;
 };
 
 export default function HomeSearchControlDock({
@@ -46,11 +47,12 @@ export default function HomeSearchControlDock({
   onRandomEntry,
   onSelectFilter,
   onCreateRoom,
+  onMenuItemIntent,
   onOpenFollow,
   onOpenSettings,
   onEnterSelectedRoom,
   isRandomEntryPending = false,
-  randomEntryErrorMessage = null,
+  actionErrorMessage = null,
 }: Props) {
   const dockRef = useRef<HTMLDivElement | null>(null);
   const [openPanel, setOpenPanel] = useState<PanelKey | null>(null);
@@ -110,11 +112,11 @@ export default function HomeSearchControlDock({
 
   return (
     <div ref={dockRef} className={styles.dock}>
-      {openPanel || randomEntryErrorMessage ? (
+      {openPanel || actionErrorMessage ? (
         <div className={styles.floatStack}>
-          {randomEntryErrorMessage ? (
+          {actionErrorMessage ? (
             <div className={styles.errorBubble} role="alert">
-              {randomEntryErrorMessage}
+              {actionErrorMessage}
             </div>
           ) : null}
           {openPanel ? (
@@ -123,6 +125,7 @@ export default function HomeSearchControlDock({
                 <HomeControlPanelShell
                   variant="menu"
                   isRandomEntryPending={isRandomEntryPending}
+                  onMenuItemIntent={onMenuItemIntent}
                   onSelectMenuItem={selectMenuItem}
                 />
               ) : (

--- a/src/features/room/list/ui/HomeRoomStage.test.tsx
+++ b/src/features/room/list/ui/HomeRoomStage.test.tsx
@@ -29,19 +29,24 @@ describe("HomeRoomStage", () => {
   it("방이 없으면 생성 안내와 방 만들기 액션을 표시한다", async () => {
     const user = userEvent.setup();
     const onCreateRoom = vi.fn();
+    const onCreateRoomIntent = vi.fn();
 
     render(
       <HomeRoomStage
         rooms={[]}
         currentRoomSlug={null}
         onCreateRoom={onCreateRoom}
+        onCreateRoomIntent={onCreateRoomIntent}
         onRequestRoomEntry={vi.fn()}
         onSelectRoom={vi.fn()}
       />,
     );
 
     expect(screen.getByText("현재 생성된 방이 없어요.")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "방 만들기" }));
+    const createButton = screen.getByRole("button", { name: "방 만들기" });
+    fireEvent.pointerEnter(createButton);
+    expect(onCreateRoomIntent).toHaveBeenCalledOnce();
+    await user.click(createButton);
     expect(onCreateRoom).toHaveBeenCalledOnce();
   });
 

--- a/src/features/room/list/ui/HomeRoomStage.tsx
+++ b/src/features/room/list/ui/HomeRoomStage.tsx
@@ -27,6 +27,7 @@ type Props = {
   isLoading?: boolean;
   selectedRoomOwner?: RoomOwner | null;
   onCreateRoom: () => void;
+  onCreateRoomIntent?: () => void;
   onSelectRoom: (roomSlug: string) => void;
   onRequestRoomEntry: (room: Room) => void;
   onRetry?: () => void;
@@ -57,6 +58,7 @@ export default function HomeRoomStage({
   isLoading = false,
   selectedRoomOwner = null,
   onCreateRoom,
+  onCreateRoomIntent,
   onSelectRoom,
   onRequestRoomEntry,
   onRetry,
@@ -138,6 +140,9 @@ export default function HomeRoomStage({
             <button
               type="button"
               className={styles.createRoomButton}
+              onFocus={onCreateRoomIntent}
+              onPointerDown={onCreateRoomIntent}
+              onPointerEnter={onCreateRoomIntent}
               onClick={onCreateRoom}
             >
               방 만들기

--- a/src/features/room/search/components/SearchScreen.tsx
+++ b/src/features/room/search/components/SearchScreen.tsx
@@ -30,6 +30,7 @@ import {
   getSelectedHomeGenreTags,
   type HomeFilterKey,
   type HomeFilterOption,
+  type HomeMenuItem,
 } from "@/src/features/room/discovery/ui/HomeControlPanelShell";
 import HomeSearchControlDock from "@/src/features/room/discovery/ui/HomeSearchControlDock";
 import { useRoomEntry } from "@/src/features/room/join/model/useRoomEntry";
@@ -41,14 +42,14 @@ import SelectedRoomOwnerBar from "@/src/features/room/list/ui/SelectedRoomOwnerB
 import SearchEmptyState from "@/src/features/room/search/ui/SearchEmptyState";
 import { mergeRoomMeta } from "@/src/features/room/model/mergeRoomMeta";
 import LazyModalFallback from "@/src/shared/ui/lazy-modal-fallback/LazyModalFallback";
+import { useIdlePreload } from "@/src/shared/lib/useIdlePreload";
+import {
+  DISCOVERY_MODAL_PRELOADERS,
+  discoveryModalResources,
+  preloadDiscoveryModalForMenuItem,
+} from "@/src/features/room/discovery/lib/discoveryModalResources";
+import { useDiscoveryModalController } from "@/src/features/room/discovery/model/useDiscoveryModalController";
 
-const RoomFormModal = dynamic(
-  () => import("@/src/features/room/create/ui/RoomFormModal"),
-  {
-    ssr: false,
-    loading: () => <LazyModalFallback label="방 만들기 화면 로딩 중" />,
-  },
-);
 const RoomJoinPasswordModal = dynamic(
   () => import("@/src/features/room/join/ui/RoomJoinPasswordModal"),
   {
@@ -56,28 +57,17 @@ const RoomJoinPasswordModal = dynamic(
     loading: () => <LazyModalFallback label="방 입장 화면 로딩 중" />,
   },
 );
-const FollowModal = dynamic(
-  () => import("@/src/features/follow/ui/FollowModal"),
-  {
-    ssr: false,
-    loading: () => <LazyModalFallback label="친구 화면 로딩 중" />,
-  },
-);
-const SettingsModal = dynamic(
-  () => import("@/src/features/settings/ui/SettingsModal"),
-  {
-    ssr: false,
-    loading: () => <LazyModalFallback label="설정 화면 로딩 중" />,
-  },
-);
+const RoomFormModal = discoveryModalResources.create.Component;
+const FollowModal = discoveryModalResources.follow.Component;
+const SettingsModal = discoveryModalResources.settings.Component;
 
 export default function SearchScreen() {
+  useIdlePreload(DISCOVERY_MODAL_PRELOADERS);
+
   const [roomListFilters, setRoomListFilters] = useState(DEFAULT_HOME_FILTERS);
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 300);
-  const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false);
-  const [isFollowModalOpen, setIsFollowModalOpen] = useState(false);
-  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const discoveryModal = useDiscoveryModalController();
   const {
     authRequiredDescription,
     closeAuthRequiredModal,
@@ -109,23 +99,26 @@ export default function SearchScreen() {
     ],
   );
 
-  const requestCreateRoom = () =>
+  const requestCreateRoom = () => {
     requestAuthenticatedAction({
       description: "방 만들기는 로그인 후 이용할 수 있어요.",
-      onAuthenticated: () => setIsCreateRoomModalOpen(true),
+      onAuthenticated: () => discoveryModal.requestModal("create"),
     });
+  };
 
-  const requestOpenFollow = () =>
+  const requestOpenFollow = () => {
     requestAuthenticatedAction({
       description: "팔로우 기능은 로그인 후 이용할 수 있어요.",
-      onAuthenticated: () => setIsFollowModalOpen(true),
+      onAuthenticated: () => discoveryModal.requestModal("follow"),
     });
+  };
 
-  const requestOpenSettings = () =>
+  const requestOpenSettings = () => {
     requestAuthenticatedAction({
       description: "설정은 로그인 후 이용할 수 있어요.",
-      onAuthenticated: () => setIsSettingsModalOpen(true),
+      onAuthenticated: () => discoveryModal.requestModal("settings"),
     });
+  };
 
   return (
     <div className={styles.container}>
@@ -135,7 +128,9 @@ export default function SearchScreen() {
 
       <SearchRoomsContent
         activeFilters={roomListFilters}
+        modalLoadErrorMessage={discoveryModal.loadErrorMessage}
         onCreateRoom={requestCreateRoom}
+        onMenuItemIntent={preloadDiscoveryModalForMenuItem}
         onOpenFollow={requestOpenFollow}
         onOpenSettings={requestOpenSettings}
         onSelectFilter={selectRoomListFilter}
@@ -143,18 +138,18 @@ export default function SearchScreen() {
         roomsQueryParams={roomListQueryParams}
         searchQuery={searchQuery}
       />
-      {isCreateRoomModalOpen ? (
+      {discoveryModal.activeModal === "create" ? (
         <RoomFormModal
           open
           mode="create"
-          onClose={() => setIsCreateRoomModalOpen(false)}
+          onClose={discoveryModal.closeModal}
         />
       ) : null}
-      {isFollowModalOpen ? (
-        <FollowModal open onClose={() => setIsFollowModalOpen(false)} />
+      {discoveryModal.activeModal === "follow" ? (
+        <FollowModal open onClose={discoveryModal.closeModal} />
       ) : null}
-      {isSettingsModalOpen ? (
-        <SettingsModal open onClose={() => setIsSettingsModalOpen(false)} />
+      {discoveryModal.activeModal === "settings" ? (
+        <SettingsModal open onClose={discoveryModal.closeModal} />
       ) : null}
       <AuthRequiredModal
         open={isAuthRequiredModalOpen}
@@ -211,7 +206,9 @@ function SearchPanelHeader({
 
 type SearchRoomsContentProps = {
   activeFilters: typeof DEFAULT_HOME_FILTERS;
+  modalLoadErrorMessage: string | null;
   onCreateRoom: () => void;
+  onMenuItemIntent: (menuItem: HomeMenuItem) => void;
   onOpenFollow: () => void;
   onOpenSettings: () => void;
   onSelectFilter: (key: HomeFilterKey, option: HomeFilterOption) => void;
@@ -222,7 +219,9 @@ type SearchRoomsContentProps = {
 
 function SearchRoomsContent({
   activeFilters,
+  modalLoadErrorMessage,
   onCreateRoom,
+  onMenuItemIntent,
   onOpenFollow,
   onOpenSettings,
   onSelectFilter,
@@ -267,6 +266,8 @@ function SearchRoomsContent({
     onSelectRoom: setCurrentRoomSlug,
   });
   const randomEntry = useRandomEntryNavigation();
+  const actionErrorMessage =
+    modalLoadErrorMessage ?? randomEntry.errorMessage;
 
   useLoadMoreRoomsNearEnd({
     rooms: roomListRooms,
@@ -312,7 +313,11 @@ function SearchRoomsContent({
         />
         {showEmptyState ? (
           <div className={styles.emptyContent}>
-            <SearchEmptyState query={searchQuery} onCreateRoom={onCreateRoom} />
+            <SearchEmptyState
+              query={searchQuery}
+              onCreateRoom={onCreateRoom}
+              onCreateRoomIntent={() => onMenuItemIntent("CREATE")}
+            />
           </div>
         ) : (
           <div className={styles.contentGrid}>
@@ -370,8 +375,9 @@ function SearchRoomsContent({
         onCreateRoom={onCreateRoom}
         onOpenFollow={onOpenFollow}
         onOpenSettings={onOpenSettings}
+        onMenuItemIntent={onMenuItemIntent}
         isRandomEntryPending={randomEntry.isPending}
-        randomEntryErrorMessage={randomEntry.errorMessage}
+        actionErrorMessage={actionErrorMessage}
         onEnterSelectedRoom={() => {
           if (selectedRoom) {
             roomEntry.requestRoomEntry(selectedRoom);

--- a/src/features/room/search/ui/SearchEmptyState.test.tsx
+++ b/src/features/room/search/ui/SearchEmptyState.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import SearchEmptyState from "./SearchEmptyState";
@@ -7,16 +7,26 @@ describe("SearchEmptyState", () => {
   it("검색어와 방 만들기 액션을 제공한다", async () => {
     const user = userEvent.setup();
     const onCreateRoom = vi.fn();
+    const onCreateRoomIntent = vi.fn();
 
     render(
-      <SearchEmptyState query="공부 음악" onCreateRoom={onCreateRoom} />,
+      <SearchEmptyState
+        query="공부 음악"
+        onCreateRoom={onCreateRoom}
+        onCreateRoomIntent={onCreateRoomIntent}
+      />,
     );
 
     expect(screen.getByText("검색 결과가 없습니다")).toBeInTheDocument();
     expect(
       screen.getByText("‘공부 음악’에 관한 방을 찾을 수 없어요."),
     ).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "방 만들러 가기" }));
+    const createButton = screen.getByRole("button", {
+      name: "방 만들러 가기",
+    });
+    fireEvent.pointerEnter(createButton);
+    expect(onCreateRoomIntent).toHaveBeenCalledOnce();
+    await user.click(createButton);
     expect(onCreateRoom).toHaveBeenCalledOnce();
   });
 });

--- a/src/features/room/search/ui/SearchEmptyState.tsx
+++ b/src/features/room/search/ui/SearchEmptyState.tsx
@@ -3,9 +3,14 @@ import styles from "./SearchEmptyState.module.css";
 type Props = {
   query: string;
   onCreateRoom: () => void;
+  onCreateRoomIntent?: () => void;
 };
 
-export default function SearchEmptyState({ query, onCreateRoom }: Props) {
+export default function SearchEmptyState({
+  query,
+  onCreateRoom,
+  onCreateRoomIntent,
+}: Props) {
   const trimmedQuery = query.trim();
   const description = trimmedQuery
     ? `‘${trimmedQuery}’에 관한 방을 찾을 수 없어요.`
@@ -15,7 +20,14 @@ export default function SearchEmptyState({ query, onCreateRoom }: Props) {
     <div className={styles.state}>
       <h2 className={styles.title}>검색 결과가 없습니다</h2>
       <p className={styles.description}>{description}</p>
-      <button type="button" className={styles.button} onClick={onCreateRoom}>
+      <button
+        type="button"
+        className={styles.button}
+        onFocus={onCreateRoomIntent}
+        onPointerDown={onCreateRoomIntent}
+        onPointerEnter={onCreateRoomIntent}
+        onClick={onCreateRoom}
+      >
         방 만들러 가기
       </button>
     </div>

--- a/src/features/settings/ui/SettingsModal.tsx
+++ b/src/features/settings/ui/SettingsModal.tsx
@@ -5,7 +5,7 @@ import AccountSettingsTab from "./AccountSettingsTab";
 import ProfileSettingsTab from "./ProfileSettingsTab";
 import styles from "./SettingsModal.module.css";
 
-type SettingsModalProps = {
+export type SettingsModalProps = {
   open: boolean;
   onClose: () => void;
 };

--- a/src/shared/lib/preloadableDynamicComponent.test.ts
+++ b/src/shared/lib/preloadableDynamicComponent.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createRetryablePreloader,
+  runAfterComponentPreload,
+} from "./preloadableDynamicComponent";
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+describe("preloadableDynamicComponent", () => {
+  it("동시 선로딩과 성공 후 호출을 하나의 로더 실행으로 합친다", async () => {
+    const deferred = createDeferred<string>();
+    const loader = vi.fn(() => deferred.promise);
+    const preload = createRetryablePreloader(loader);
+
+    const firstLoad = preload();
+    const concurrentLoad = preload();
+
+    expect(concurrentLoad).toBe(firstLoad);
+    expect(loader).toHaveBeenCalledOnce();
+
+    deferred.resolve("loaded");
+    await expect(firstLoad).resolves.toBe("loaded");
+    await expect(preload()).resolves.toBe("loaded");
+    expect(loader).toHaveBeenCalledOnce();
+  });
+
+  it("실패한 선로딩 캐시를 비워 다음 호출에서 재시도한다", async () => {
+    const loader = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("chunk failed"))
+      .mockResolvedValueOnce("loaded");
+    const preload = createRetryablePreloader(loader);
+
+    await expect(preload()).rejects.toThrow("chunk failed");
+    await expect(preload()).resolves.toBe("loaded");
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("성공 전에는 열지 않고 실패 시 오류 콜백만 호출한다", async () => {
+    const success = createDeferred<unknown>();
+    const onReady = vi.fn();
+    const onError = vi.fn();
+
+    runAfterComponentPreload(() => success.promise, onReady, onError);
+    expect(onReady).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
+    success.resolve(undefined);
+    await success.promise;
+    await Promise.resolve();
+    expect(onReady).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+
+    const failure = new Error("chunk failed");
+    runAfterComponentPreload(
+      () => Promise.reject(failure),
+      onReady,
+      onError,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onReady).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+});

--- a/src/shared/lib/preloadableDynamicComponent.tsx
+++ b/src/shared/lib/preloadableDynamicComponent.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { ComponentType } from "react";
+
+export type ComponentPreloader = () => Promise<unknown>;
+
+export function createRetryablePreloader<Module>(
+  loader: () => Promise<Module>,
+) {
+  let activeLoad: Promise<Module> | null = null;
+
+  return () => {
+    if (!activeLoad) {
+      activeLoad = loader().catch((error: unknown) => {
+        activeLoad = null;
+        throw error;
+      });
+    }
+
+    return activeLoad;
+  };
+}
+
+export function createPreloadableDynamicComponent<Props>(
+  loader: () => Promise<{ default: ComponentType<Props> }>,
+) {
+  const preload = createRetryablePreloader(loader);
+  const Component = dynamic<Props>(() => preload(), {
+    loading: () => null,
+    ssr: false,
+  });
+
+  return { Component, preload };
+}
+
+export function requestComponentPreload(preload: ComponentPreloader) {
+  void preload().catch(() => undefined);
+}
+
+export function runAfterComponentPreload(
+  preload: ComponentPreloader,
+  onReady: () => void,
+  onError: (error: unknown) => void,
+) {
+  void preload().then(onReady, onError);
+}

--- a/src/shared/lib/useIdlePreload.test.tsx
+++ b/src/shared/lib/useIdlePreload.test.tsx
@@ -1,0 +1,72 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useIdlePreload } from "./useIdlePreload";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useIdlePreload", () => {
+  it("브라우저 idle 시 모든 리소스를 선로딩하고 예약을 정리한다", () => {
+    let idleCallback: IdleRequestCallback | null = null;
+    const requestIdleCallback = vi.fn(
+      (callback: IdleRequestCallback, options?: IdleRequestOptions) => {
+        idleCallback = callback;
+        expect(options).toEqual({ timeout: 1_500 });
+        return 42;
+      },
+    );
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", cancelIdleCallback);
+    const firstPreload = vi.fn().mockResolvedValue(undefined);
+    const secondPreload = vi.fn().mockResolvedValue(undefined);
+
+    const { unmount } = renderHook(() =>
+      useIdlePreload([firstPreload, secondPreload]),
+    );
+
+    expect(firstPreload).not.toHaveBeenCalled();
+    act(() => {
+      idleCallback?.({
+        didTimeout: false,
+        timeRemaining: () => 10,
+      });
+    });
+    expect(firstPreload).toHaveBeenCalledOnce();
+    expect(secondPreload).toHaveBeenCalledOnce();
+
+    unmount();
+    expect(cancelIdleCallback).toHaveBeenCalledWith(42);
+  });
+
+  it("idle API가 없으면 1500ms 후 선로딩하고 unmount 시 타이머를 정리한다", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestIdleCallback", undefined);
+    vi.stubGlobal("cancelIdleCallback", undefined);
+    const preload = vi.fn().mockRejectedValue(new Error("chunk failed"));
+
+    const firstRender = renderHook(() => useIdlePreload([preload]));
+    act(() => {
+      vi.advanceTimersByTime(1_499);
+    });
+    expect(preload).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(preload).toHaveBeenCalledOnce();
+    firstRender.unmount();
+
+    const canceledPreload = vi.fn().mockResolvedValue(undefined);
+    const secondRender = renderHook(() =>
+      useIdlePreload([canceledPreload]),
+    );
+    secondRender.unmount();
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+    expect(canceledPreload).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/useIdlePreload.ts
+++ b/src/shared/lib/useIdlePreload.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  requestComponentPreload,
+  type ComponentPreloader,
+} from "./preloadableDynamicComponent";
+
+const IDLE_PRELOAD_TIMEOUT_MS = 1_500;
+const FALLBACK_PRELOAD_DELAY_MS = 1_500;
+
+export function useIdlePreload(
+  preloaders: readonly ComponentPreloader[],
+) {
+  useEffect(() => {
+    const preload = () => {
+      preloaders.forEach(requestComponentPreload);
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      const idleCallbackId = window.requestIdleCallback(preload, {
+        timeout: IDLE_PRELOAD_TIMEOUT_MS,
+      });
+
+      return () => window.cancelIdleCallback(idleCallbackId);
+    }
+
+    const timeoutId = window.setTimeout(
+      preload,
+      FALLBACK_PRELOAD_DELAY_MS,
+    );
+
+    return () => window.clearTimeout(timeoutId);
+  }, [preloaders]);
+}


### PR DESCRIPTION
## 변경 내용

- CREATE, FOLLOW, SETTING 모달의 코드 스플리팅은 유지하면서 화면 idle 시점과 hover·focus·pointer intent에서 청크를 미리 받습니다.
- 클릭 시 청크 로딩이 성공한 다음에만 모달을 열어 기존 전체 화면 로딩 스피너가 나타나지 않게 했습니다.
- 느린 네트워크에서 서로 다른 메뉴를 연속 클릭해도 discovery 모달은 하나만 열리도록 단일 reservation을 적용했습니다.
- 선로딩 실패 시 화면은 유지하고 접근 가능한 오류 문구를 표시하며, 같은 액션 재클릭으로 청크 로딩을 재시도합니다.
- 홈·검색 데스크톱 메뉴, 모바일 빠른 메뉴, 방이 없는 상태의 CREATE 버튼까지 동일한 intent 선로딩을 연결했습니다.

## 원인

기존에는 메뉴 클릭과 동시에 dynamic modal state를 열었고, 아직 청크가 내려받아지지 않은 경우 Next dynamic의 page-level fallback이 전체 화면 로딩 UI를 렌더했습니다.

## 영향 범위

- [x] 홈·검색 discovery 메뉴
- [x] 모바일 홈 빠른 메뉴
- [x] CREATE·FOLLOW·SETTING 모달 로딩 및 오류 상태
- [ ] API 계약
- [ ] 서버 캐시·실시간 연결

## 검증

- [x] `npm run lint`
- [x] `npm run test` — 108 files / 330 tests
- [x] `npm run build` — Next.js 16.1.1, 8/8 routes
- [x] `git diff --check`
- [x] production bundle에서 CREATE/FOLLOW/SETTING 별도 chunk 유지 확인
- [x] fresh read-only QA — PASS

## 잔여 위험

Browser runtime에 연결 가능한 브라우저 인스턴스가 없어 실제 첫 클릭 smoke test는 자동화하지 못했습니다. 단위·상태·UI interaction 테스트와 production bundle 검증으로 대체했습니다.

## 기능별 커밋

- `bb6808a fix(discovery): 지연 모달 클릭 전 선로딩`
- `88b12c5 docs(delivery): 모달 선로딩 검증 기록`

## 추적 정보

- 실행 계획: `docs/exec-plans/active/2026-08-10-discovery-modal-preload/`
- 브랜치: `dev → main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 홈 및 검색 화면의 방 생성, 팔로우, 설정 모달을 미리 로드해 클릭 후 더 빠르게 표시합니다.
  - 메뉴에 마우스를 올리거나 포커스하면 해당 모달을 선행 준비합니다.
  - 로딩 중 중복 모달 요청을 방지하고, 실패한 모달 로딩은 다시 시도할 수 있습니다.
  - 모달 로딩 오류를 화면에서 안내합니다.

- **테스트**
  - 모달 선행 로딩, 재시도, 메뉴 상호작용 및 오류 처리를 검증했습니다.

- **문서**
  - 기능 계획, UI 흐름, QA 결과를 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->