### PR TITLE
fix(room): 참가자 메뉴와 채팅 지연 피드백 정리

### DIFF
--- a/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/delivery-state.md
@@ -1,0 +1,12 @@
+# Delivery State
+
+- status: ready
+- branch: `dev`
+- base: `main`
+- issue:
+- pr:
+- selected_skills: feature-delivery, orchestrator, ui-flow, api-boundary, frontend guardrails, qa-reviewer
+- local_qa: targeted 15 passed; full 323 passed; lint passed; build passed; fresh QA pass
+- ci: pending implementation
+- review_threads: not inspected
+- next_action: commit and push dev

--- a/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/plan.md
+++ b/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/plan.md
@@ -1,0 +1,53 @@
+# 방 관리 UI 수정
+
+## Scope
+
+- 참가자 가상 목록의 관리 드롭다운이 다른 행 뒤로 들어가거나 잘리지 않게 한다.
+- 방 수정 모달의 방 사진 필드는 backend 수정 범위가 필요해 이번 전달에서 제외한다.
+- 채팅 전송 확인 timeout은 내부 pending 정리만 수행하고 사용자 오류 문구로 노출하지 않는다.
+
+## Selected Skills
+
+- `queuing-feature-delivery`
+- `queuing-orchestrator`
+- `queuing-ui-flow`
+- `queuing-api-boundary`
+- `frontend-architecture-guardrails`
+- `queuing-qa-reviewer`
+
+## Ownership
+
+- 참가자 메뉴 stacking/overflow: `RoomParticipantList`와 참가자 CSS module
+- 채팅 confirmation lifecycle: `useRoomChatRealtime`
+- 방 수정 폼 상태: `useEditRoomForm`
+- 방 사진 저장 계약: backend 지원 여부 확인 후 API client와 mutation hook
+
+## Acceptance Criteria
+
+- 열린 참가자 메뉴가 인접 행보다 위에 표시되고 목록 경계 안에서 위/아래 배치된다.
+- 채팅 confirmation timeout 뒤 pending 상태와 타이머는 정리되지만 지연 오류 문구는 비어 있다.
+- backend 계약 없이 저장되지 않는 방 사진 필드를 노출하지 않는다.
+- targeted test, lint, full test, build가 통과한다.
+
+## Contract Finding
+
+- 2026-08-10 기준 backend `main`의 `UpdateRoomRequest`에는 사진 필드가 없고, `RoomThumbnailV2Controller`는 생성 전 임시 업로드 POST만 제공한다.
+- 프론트 전용으로 저장되지 않는 필드를 만들지 않는다. backend 변경 권한 확인 전 사진 저장 구현은 blocked 상태다.
+
+## Commit Slices
+
+1. `fix(room): 참가자 메뉴와 채팅 지연 피드백 정리`
+
+## Progress
+
+- [x] 관련 UI와 최신 backend 계약 확인
+- [x] 참가자 드롭다운 stacking 수정과 테스트
+- [x] 채팅 지연 문구 제거와 테스트
+- [x] 방 사진 수정 제외 결정 (사용자가 backend 변경을 진행하지 않기로 함)
+- [x] targeted test, lint, build
+- [x] full test, fresh QA (`pass`)
+- [ ] commit, push
+
+## Residual Risk
+
+- 방 사진 수정은 backend 계약 없이 프론트만 먼저 배포할 수 없어 미반영 상태다.

--- a/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/qa-report.md
+++ b/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/qa-report.md
@@ -1,0 +1,31 @@
+# QA Report
+
+## Result
+
+- fresh QA: `pass`
+- blocking findings: none
+
+## Verification
+
+- targeted: 2 files, 15 tests passed
+- full suite: 105 files, 323 tests passed
+- lint: passed
+- production build: passed
+- diff check: passed
+
+## Boundary Review
+
+- 참가자 목록의 mounted card 상한은 24개로 유지된다.
+- 열린 virtual row만 높은 stacking 순서를 가지며 메뉴를 자르던 paint containment는 제거됐다.
+- 메뉴의 위/아래 배치와 스크롤 시 닫기 동작은 유지된다.
+- 채팅 confirmation timeout은 pending, sending 상태, timer를 정리하되 오류 문구를 만들지 않는다.
+- backend가 보낸 실제 채팅 오류 문구는 기존 경로로 계속 노출된다.
+
+## Excluded Request
+
+- 방 사진 수정은 backend `main`에 저장 계약이 없고 사용자가 backend 변경을 진행하지 않기로 해 미반영했다.
+
+## Residual Risk
+
+- 실제 브라우저 paint 결과를 수동 확인하지는 않았다.
+- 메뉴보다 목록 자체가 짧은 극단적인 viewport에서는 목록 overflow에 의해 일부가 잘릴 수 있다.

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,5 +1,7 @@
 # Active Execution Plans
 
+- [2026-08-10-room-management-ui-fixes](./2026-08-10-room-management-ui-fixes/plan.md): ready — 참가자 메뉴와 채팅 지연 피드백 정리
+
 - [2026-08-10-discovery-modal-static-import](./2026-08-10-discovery-modal-static-import/plan.md): ready — Draft PR #40, CREATE·FOLLOW·SETTING 정적 import 단순화 및 CI 통과
 
 - [2026-08-10-discovery-modal-preload](./2026-08-10-discovery-modal-preload/plan.md): merged — PR #39, CREATE·FOLLOW·SETTING 지연 모달 클릭 스피너 제거 및 CI 통과

--- a/src/features/room/chat/hooks/useRoomChatRealtime.test.tsx
+++ b/src/features/room/chat/hooks/useRoomChatRealtime.test.tsx
@@ -154,7 +154,8 @@ describe("useRoomChatRealtime 전송 오류 표시", () => {
       await vi.advanceTimersByTimeAsync(6_000);
     });
     expect(backfill).toHaveBeenCalledTimes(1);
-    expect(result.current.sendErrorMessage).toContain("전송 확인이 지연");
+    expect(result.current.sendErrorMessage).toBe("");
+    expect(result.current.isSending).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
     unmount();
   });
@@ -189,7 +190,8 @@ describe("useRoomChatRealtime 전송 오류 표시", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4_000);
     });
-    expect(result.current.sendErrorMessage).toContain("전송 확인이 지연");
+    expect(result.current.sendErrorMessage).toBe("");
+    expect(result.current.isSending).toBe(false);
     expect(backfill).toHaveBeenCalledTimes(2);
     expect(backfill).toHaveBeenLastCalledWith(["같은 내용"]);
 
@@ -199,7 +201,7 @@ describe("useRoomChatRealtime 전송 오류 표시", () => {
       await Promise.resolve();
     });
     expect(backfill).toHaveBeenCalledTimes(2);
-    expect(result.current.sendErrorMessage).toContain("전송 확인이 지연");
+    expect(result.current.sendErrorMessage).toBe("");
     unmount();
   });
 
@@ -224,7 +226,8 @@ describe("useRoomChatRealtime 전송 오류 표시", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(6_000);
     });
-    expect(result.current.sendErrorMessage).toContain("전송 확인이 지연");
+    expect(result.current.sendErrorMessage).toBe("");
+    expect(result.current.isSending).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
 
     act(() => {
@@ -248,7 +251,8 @@ describe("useRoomChatRealtime 전송 오류 표시", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(6_000);
     });
-    expect(result.current.sendErrorMessage).toContain("전송 확인이 지연");
+    expect(result.current.sendErrorMessage).toBe("");
+    expect(result.current.isSending).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
     unmount();
   });

--- a/src/features/room/chat/hooks/useRoomChatRealtime.ts
+++ b/src/features/room/chat/hooks/useRoomChatRealtime.ts
@@ -30,8 +30,6 @@ type UseRoomChatRealtimeParams = {
 
 const CHAT_SEND_BACKFILL_DELAY_MS = 2000;
 const CHAT_SEND_CONFIRM_TIMEOUT_MS = 8000;
-const CHAT_SEND_CONFIRM_TIMEOUT_MESSAGE =
-  "채팅 전송 확인이 지연되었습니다. 네트워크 상태를 확인해주세요.";
 
 type PendingChatSend = {
   backfillAt: number;
@@ -266,14 +264,13 @@ export function useRoomChatRealtime({
     );
     releaseOrphanedBackfillRequest();
     setIsChatSending(false);
-    setChatSendErrorMessage(CHAT_SEND_CONFIRM_TIMEOUT_MESSAGE);
     return true;
   }, [releaseOrphanedBackfillRequest]);
 
   const runPendingCheck = useCallback(async () => {
     const pendingGeneration = pendingGenerationRef.current;
     const now = Date.now();
-    let didExpirePendingSend = expirePendingChatSends(now);
+    expirePendingChatSends(now);
     const dueBackfillSends = pendingChatSendsRef.current.filter(
       (pending) => !pending.backfillAttempted && pending.backfillAt <= now,
     );
@@ -305,16 +302,11 @@ export function useRoomChatRealtime({
     if (pendingBackfillRequestRef.current === backfillRequest) {
       pendingBackfillRequestRef.current = null;
     }
-    didExpirePendingSend =
-      expirePendingChatSends(Date.now()) || didExpirePendingSend;
+    expirePendingChatSends(Date.now());
     resolvePersistedPendingChatSends(
       foundContents,
       backfillRequest.pendingIds,
     );
-    if (didExpirePendingSend) {
-      setChatSendErrorMessage(CHAT_SEND_CONFIRM_TIMEOUT_MESSAGE);
-    }
-
     schedulePendingCheck();
   }, [
     expirePendingChatSends,

--- a/src/features/room/participants/ui/RoomParticipantList.test.tsx
+++ b/src/features/room/participants/ui/RoomParticipantList.test.tsx
@@ -222,6 +222,10 @@ describe("RoomParticipantList", () => {
     await user.click(trigger);
 
     expect(screen.getByRole("menu", { name: "회원 참가자 관리" })).toBeVisible();
+    expect(trigger.closest("[data-participant-key]")).toHaveAttribute(
+      "data-expanded",
+      "true",
+    );
     expect(screen.getByRole("menuitem", { name: "팔로우" })).toBeVisible();
     expect(screen.getByRole("menuitem", { name: "신고" })).toBeVisible();
     expect(screen.getByRole("menuitem", { name: "차단" })).toBeVisible();
@@ -230,6 +234,9 @@ describe("RoomParticipantList", () => {
 
     await user.click(trigger);
     expect(screen.queryByRole("menu", { name: "회원 참가자 관리" })).toBeNull();
+    expect(trigger.closest("[data-participant-key]")).not.toHaveAttribute(
+      "data-expanded",
+    );
   });
 
   it("다른 카드, 바깥 클릭, Escape로 하나의 메뉴만 관리한다", async () => {

--- a/src/features/room/participants/ui/RoomParticipantList.tsx
+++ b/src/features/room/participants/ui/RoomParticipantList.tsx
@@ -284,6 +284,7 @@ export default function RoomParticipantList({
               key={participantKey}
               className={styles.virtualRow}
               data-participant-key={participantKey}
+              data-expanded={expanded || undefined}
               style={
                 {
                   "--participant-index": effectiveWindowStart + visibleIndex,

--- a/src/features/room/participants/ui/RoomParticipantsPanel.module.css
+++ b/src/features/room/participants/ui/RoomParticipantsPanel.module.css
@@ -67,11 +67,13 @@
   );
 }
 
+.virtualRow[data-expanded="true"] {
+  z-index: 10;
+}
+
 .participantItem {
   position: relative;
   flex-shrink: 0;
-  content-visibility: auto;
-  contain-intrinsic-size: auto 58px;
   border: 1px solid transparent;
   border-radius: 10px;
   transition:


### PR DESCRIPTION
<!-- 제목 예시: feat: 방 즐겨찾기 기능 추가 -->

## 변경 내용

<!-- 핵심 변경을 1~3개로 요약해주세요. -->

-

## 변경 이유

<!-- 사용자 문제, 버그 원인, 기술 부채 등 이 변경이 필요한 이유를 적어주세요. -->

-

## 영향 범위

<!-- 해당 항목만 남기거나 체크해주세요. -->

- [ ] UI / 사용자 흐름
- [ ] API 요청·응답 계약
- [ ] React Query 캐시
- [ ] WebSocket / 실시간 상태
- [ ] 인증 / 보안
- [ ] 문서 / 개발 도구

## 검증

- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] 관련 수동 시나리오 확인
- [ ] 실패·로딩·빈 상태 확인

검증 결과 및 재현 방법:

-

## 리뷰 포인트

<!-- 리뷰어가 집중해서 볼 경계, 선택한 대안, 확인이 필요한 부분을 적어주세요. -->

-

## 기능별 커밋

<!-- 기능 단위 커밋과 각 커밋이 검증하는 동작을 정리해주세요. -->

-

## 위험 및 후속 작업

<!-- 남은 위험이 없으면 "없음"으로 명시해주세요. -->

-

## 추적 정보

- Linked issue: Closes #
- Execution plan: `docs/exec-plans/...`
- Selected skills:
- QA result: `pass | fix | redo`

## 화면 변경

<!-- UI 변경 시 스크린샷 또는 영상을 첨부해주세요. 해당 없으면 섹션을 삭제해도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 참가자 메뉴를 열 때 메뉴가 다른 참가자 카드에 가려지지 않도록 표시 순서와 배치를 개선했습니다.
  - 채팅 전송 확인이 지연되거나 만료되어도 불필요한 오류 문구가 표시되지 않으며, 전송 상태가 정상적으로 정리됩니다.
  - 스크롤 중 참가자 메뉴 표시 상태가 안정적으로 유지되도록 개선했습니다.

- **문서**
  - 방 관리 UI 수정 계획과 QA 결과, 진행 상태를 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->