### PR TITLE
fix: 방 관리 메뉴와 탐색 모달 안정화

### DIFF
--- a/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/delivery-state.md
@@ -1,0 +1,12 @@
+# Delivery State
+
+- status: ready
+- branch: `dev`
+- base: `main`
+- issue:
+- pr:
+- selected_skills: feature-delivery, ui-flow, frontend guardrails, qa-reviewer
+- local_qa: targeted 10 passed; full 323 passed; lint passed; build passed; fresh QA pass
+- ci: not requested
+- review_threads: not inspected
+- next_action: commit and push dev

--- a/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/delivery-state.md
@@ -1,12 +1,12 @@
 # Delivery State
 
-- status: ready
+- status: ci-pending
 - branch: `dev`
 - base: `main`
 - issue:
-- pr:
+- pr: [#42](https://github.com/Queuing-org/frontend/pull/42) (draft)
 - selected_skills: feature-delivery, ui-flow, frontend guardrails, qa-reviewer
 - local_qa: targeted 10 passed; full 323 passed; lint passed; build passed; fresh QA pass
-- ci: not requested
+- ci: pending
 - review_threads: not inspected
-- next_action: commit and push dev
+- next_action: GitHub Actions와 review 확인

--- a/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/plan.md
+++ b/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/plan.md
@@ -26,4 +26,4 @@
 
 - [x] 원인 확인과 구현
 - [x] 검증과 fresh QA (`pass`)
-- [ ] commit, push
+- [x] commit, push, Draft PR #42

--- a/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/plan.md
+++ b/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/plan.md
@@ -1,0 +1,29 @@
+# 채팅 관리 메뉴 레이어 수정
+
+## Scope
+
+- 채팅 메시지 관리 드롭다운이 인접 메시지 뒤로 들어가거나 paint containment에 잘리지 않게 한다.
+- 닫힌 메시지의 `content-visibility` 최적화와 최대 500개 DOM 상한은 유지한다.
+
+## Selected Skills
+
+- `queuing-feature-delivery`
+- `queuing-ui-flow`
+- `frontend-architecture-guardrails`
+- `queuing-qa-reviewer`
+
+## Acceptance Criteria
+
+- 열린 메시지 행만 높은 stacking 순서와 visible content를 사용한다.
+- 다른 메뉴로 전환하거나 닫으면 이전 행의 열린 상태가 제거된다.
+- targeted test, lint, full test, build, fresh QA가 통과한다.
+
+## Commit
+
+1. `fix(chat): 관리 드롭다운 레이어 수정`
+
+## Progress
+
+- [x] 원인 확인과 구현
+- [x] 검증과 fresh QA (`pass`)
+- [ ] commit, push

--- a/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/qa-report.md
+++ b/docs/exec-plans/active/2026-08-10-chat-management-menu-layer/qa-report.md
@@ -1,0 +1,25 @@
+# QA Report
+
+## Result
+
+- fresh QA: `pass`
+- blocking findings: none
+
+## Verification
+
+- targeted: ChatArea 10 tests passed
+- full suite: 105 files, 323 tests passed
+- lint: passed
+- production build: passed
+- diff check: passed
+
+## Review
+
+- 열린 메시지 행에만 `data-menu-open`, `z-index`, `content-visibility: visible`이 적용된다.
+- 닫힌 행의 `content-visibility: auto`와 최대 500개 메시지 상한은 유지된다.
+- 메뉴 전환, 재클릭, Escape, 바깥 클릭, 스크롤 닫기 동작은 유지된다.
+
+## Residual Risk
+
+- 실제 브라우저 시각 QA는 수행하지 않았다.
+- 메뉴보다 채팅 목록 자체가 짧은 극단적인 viewport에서는 기존 overflow clipping 가능성이 남는다.

--- a/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/delivery-state.md
@@ -1,12 +1,12 @@
 # Delivery State
 
-- status: ready
+- status: ci-pending
 - branch: `dev`
 - base: `main`
 - issue:
-- pr:
+- pr: [#42](https://github.com/Queuing-org/frontend/pull/42) (draft)
 - selected_skills: feature-delivery, orchestrator, ui-flow, api-boundary, frontend guardrails, qa-reviewer
 - local_qa: targeted 15 passed; full 323 passed; lint passed; build passed; fresh QA pass
-- ci: pending implementation
+- ci: pending
 - review_threads: not inspected
-- next_action: commit and push dev
+- next_action: GitHub Actions와 review 확인

--- a/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/plan.md
+++ b/docs/exec-plans/active/2026-08-10-room-management-ui-fixes/plan.md
@@ -46,7 +46,7 @@
 - [x] 방 사진 수정 제외 결정 (사용자가 backend 변경을 진행하지 않기로 함)
 - [x] targeted test, lint, build
 - [x] full test, fresh QA (`pass`)
-- [ ] commit, push
+- [x] commit, push, Draft PR #42
 
 ## Residual Risk
 

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,8 +1,8 @@
 # Active Execution Plans
 
-- [2026-08-10-chat-management-menu-layer](./2026-08-10-chat-management-menu-layer/plan.md): ready — 채팅 관리 드롭다운 레이어 수정
+- [2026-08-10-chat-management-menu-layer](./2026-08-10-chat-management-menu-layer/plan.md): ci-pending — Draft PR #42, 채팅 관리 드롭다운 레이어 수정
 
-- [2026-08-10-room-management-ui-fixes](./2026-08-10-room-management-ui-fixes/plan.md): ready — 참가자 메뉴와 채팅 지연 피드백 정리
+- [2026-08-10-room-management-ui-fixes](./2026-08-10-room-management-ui-fixes/plan.md): ci-pending — Draft PR #42, 참가자 메뉴와 채팅 지연 피드백 정리
 
 - [2026-08-10-discovery-modal-static-import](./2026-08-10-discovery-modal-static-import/plan.md): ready — Draft PR #40, CREATE·FOLLOW·SETTING 정적 import 단순화 및 CI 통과
 

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,5 +1,7 @@
 # Active Execution Plans
 
+- [2026-08-10-chat-management-menu-layer](./2026-08-10-chat-management-menu-layer/plan.md): ready — 채팅 관리 드롭다운 레이어 수정
+
 - [2026-08-10-room-management-ui-fixes](./2026-08-10-room-management-ui-fixes/plan.md): ready — 참가자 메뉴와 채팅 지연 피드백 정리
 
 - [2026-08-10-discovery-modal-static-import](./2026-08-10-discovery-modal-static-import/plan.md): ready — Draft PR #40, CREATE·FOLLOW·SETTING 정적 import 단순화 및 CI 통과

--- a/src/features/room/chat/ui/ChatArea.module.css
+++ b/src/features/room/chat/ui/ChatArea.module.css
@@ -39,6 +39,11 @@
   padding-right: 28px;
 }
 
+.message[data-menu-open="true"] {
+  z-index: 10;
+  content-visibility: visible;
+}
+
 .management {
   position: absolute;
   top: 0;

--- a/src/features/room/chat/ui/ChatArea.test.tsx
+++ b/src/features/room/chat/ui/ChatArea.test.tsx
@@ -222,11 +222,20 @@ describe("ChatArea 관리 메뉴", () => {
     expect(screen.queryByRole("button", { name: /식별없음 메시지.*관리 메뉴/ })).not.toBeInTheDocument();
 
     await user.click(getMenuTrigger("회원"));
+    expect(
+      getMenuTrigger("회원").closest("[data-chat-message-key]"),
+    ).toHaveAttribute("data-menu-open", "true");
     expect(screen.getByRole("menuitem", { name: "팔로우" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "신고" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "차단" })).toBeInTheDocument();
 
     await user.click(getMenuTrigger("비회원"));
+    expect(
+      getMenuTrigger("회원").closest("[data-chat-message-key]"),
+    ).not.toHaveAttribute("data-menu-open");
+    expect(
+      getMenuTrigger("비회원").closest("[data-chat-message-key]"),
+    ).toHaveAttribute("data-menu-open", "true");
     expect(screen.getAllByRole("menu")).toHaveLength(1);
     expect(screen.getByRole("menuitem", { name: "신고" })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: "차단" })).not.toBeInTheDocument();

--- a/src/features/room/chat/ui/ChatArea.tsx
+++ b/src/features/room/chat/ui/ChatArea.tsx
@@ -105,7 +105,11 @@ function ChatMessageRow({
   const menuId = `chat-message-menu-${messageKey.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 
   return (
-    <li className={styles.message} data-chat-message-key={messageKey}>
+    <li
+      className={styles.message}
+      data-chat-message-key={messageKey}
+      data-menu-open={isMenuOpen || undefined}
+    >
       <div className={styles.avatarWrap}>
         {message.senderProfileImageUrl ? (
           <Image


### PR DESCRIPTION
## 변경 내용

- 홈·검색의 생성/수정 모달을 정적 import로 단순화하고 사용하지 않는 idle/hover preload 경로를 제거했습니다.
- 참가자 목록과 채팅 메시지의 관리 드롭다운이 행 뒤로 들어가거나 잘리는 stacking 문제를 수정했습니다.
- 채팅 전송 확인 timeout은 내부 pending 상태만 정리하고 지연 오류 문구는 노출하지 않도록 변경했습니다.
- 방 내부 채팅과 참가자 목록의 스크롤바를 투명 track, 연한 thumb, 화살표 없는 형태로 통일했습니다.

## 변경 이유

- 모달 선로딩 경로가 실제 사용자 흐름보다 복잡해 유지보수 비용과 불필요한 상태 전이를 만들고 있었습니다.
- `content-visibility`의 paint containment와 행별 stacking 순서 때문에 관리 드롭다운이 인접 행 뒤에 표시되거나 잘렸습니다.
- 채팅 전송 확인 지연은 backfill과 pending 정리로 복구되는 내부 상태이므로 사용자 오류로 계속 노출할 필요가 없습니다.
- 운영체제 기본 스크롤바의 진한 track과 Windows 화살표가 방 내부 패널 디자인과 맞지 않았습니다.

## 영향 범위

- [x] UI / 사용자 흐름
- [ ] API 요청·응답 계약
- [ ] React Query 캐시
- [x] WebSocket / 실시간 상태
- [ ] 인증 / 보안
- [x] 문서 / 개발 도구

## 검증

- [x] `npm run lint`
- [x] `npm run test` — 105 files, 323 tests passed
- [x] `npm run build`
- [ ] 관련 수동 시나리오 확인
- [x] 실패·로딩·빈 상태 확인

검증 결과 및 재현 방법:

- 참가자 관리 메뉴와 채팅 관리 메뉴의 열림/전환/닫힘 상태를 컴포넌트 테스트로 확인했습니다.
- 채팅 confirmation timeout 뒤 오류 문구, pending 상태, 타이머 정리를 훅 테스트로 확인했습니다.
- 실제 브라우저 시각 QA는 수행하지 않았습니다.
- Firefox와 WebKit 계열의 scrollbar 스타일 경계를 각각 코드 검토했습니다.

## 리뷰 포인트

- 열린 행만 높은 stacking 순서와 visible content를 사용하고, 닫힌 채팅 행의 렌더 최적화는 유지되는지 확인해주세요.
- 채팅 timeout 문구 제거 후에도 실제 WebSocket 서버 오류는 기존 경로로 노출되는지 확인해주세요.
- 모달 정적 import 전환 뒤 홈·검색의 모달 열기 경로가 동일하게 유지되는지 확인해주세요.
- Windows 환경에서 스크롤바 화살표가 숨겨지고 track이 투명하게 보이는지 확인해주세요.

## 기능별 커밋

- `9797ddf refactor(discovery): 탐색 모달 정적 import로 단순화`
- `5bce736 fix(room): 참가자 메뉴와 채팅 지연 피드백 정리`
- `fe707a5 fix(chat): 관리 드롭다운 레이어 수정`
- `87aca31 style(room): 내부 목록 스크롤바 통일`
- 관련 delivery 문서 갱신 커밋 포함

## 위험 및 후속 작업

- 극단적으로 낮은 viewport에서 메뉴 위·아래 공간이 모두 부족하면 스크롤 컨테이너 overflow로 일부가 잘릴 수 있습니다.
- 실제 브라우저에서 드롭다운 paint 결과를 한 번 확인하는 것을 권장합니다.

## 추적 정보

- Linked issue: 없음
- Execution plans:
  - `docs/exec-plans/active/2026-08-10-discovery-modal-static-import/`
  - `docs/exec-plans/active/2026-08-10-room-management-ui-fixes/`
  - `docs/exec-plans/active/2026-08-10-chat-management-menu-layer/`
  - `docs/exec-plans/active/2026-08-10-room-scrollbar-style/`
- Selected skills: `queuing-feature-delivery`, `queuing-ui-flow`, `frontend-architecture-guardrails`, `queuing-qa-reviewer`
- QA result: `pass`
