### PR TITLE
style: 방 내부 스크롤바 통일

### DIFF
--- a/docs/exec-plans/active/2026-08-10-room-scrollbar-style/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-10-room-scrollbar-style/delivery-state.md
@@ -1,0 +1,12 @@
+# Delivery State
+
+- status: ci-pending
+- branch: `dev`
+- base: `main`
+- issue:
+- pr: [#42](https://github.com/Queuing-org/frontend/pull/42) (draft)
+- selected_skills: feature-delivery, ui-flow, frontend guardrails, qa-reviewer
+- local_qa: targeted 19 passed; full 323 passed; lint passed; build passed; fresh QA pass
+- ci: pending
+- review_threads: not inspected
+- next_action: GitHub Actions와 review 확인

--- a/docs/exec-plans/active/2026-08-10-room-scrollbar-style/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-10-room-scrollbar-style/delivery-state.md
@@ -4,7 +4,7 @@
 - branch: `dev`
 - base: `main`
 - issue:
-- pr: [#42](https://github.com/Queuing-org/frontend/pull/42) (draft)
+- pr: [#43](https://github.com/Queuing-org/frontend/pull/43) (draft)
 - selected_skills: feature-delivery, ui-flow, frontend guardrails, qa-reviewer
 - local_qa: targeted 19 passed; full 323 passed; lint passed; build passed; fresh QA pass
 - ci: pending

--- a/docs/exec-plans/active/2026-08-10-room-scrollbar-style/plan.md
+++ b/docs/exec-plans/active/2026-08-10-room-scrollbar-style/plan.md
@@ -1,0 +1,31 @@
+# 방 내부 스크롤바 스타일 통일
+
+## Scope
+
+- 방 내부 채팅과 참가자 목록의 스크롤바 track을 투명하게 만든다.
+- thumb를 얇고 연한 회색으로 통일하고 hover에서만 조금 진하게 만든다.
+- WebKit/Chromium 계열 Windows 스크롤바의 화살표 버튼과 corner 배경을 제거한다.
+
+## Selected Skills
+
+- `queuing-feature-delivery`
+- `queuing-ui-flow`
+- `frontend-architecture-guardrails`
+- `queuing-qa-reviewer`
+
+## Acceptance Criteria
+
+- 채팅과 참가자 목록이 같은 scrollbar 스타일을 사용한다.
+- Firefox는 `scrollbar-color/width`, Chromium/Safari는 WebKit pseudo-element로 대응한다.
+- track/corner는 투명하고 scrollbar button은 크기 0으로 숨긴다.
+- 기존 스크롤 동작과 목록 레이아웃이 유지된다.
+
+## Commit
+
+1. `style(room): 내부 목록 스크롤바 통일`
+
+## Progress
+
+- [x] 구현
+- [x] targeted test, lint, full test, build, fresh QA (`pass`)
+- [x] commit, push, Draft PR #42 갱신

--- a/docs/exec-plans/active/2026-08-10-room-scrollbar-style/plan.md
+++ b/docs/exec-plans/active/2026-08-10-room-scrollbar-style/plan.md
@@ -28,4 +28,4 @@
 
 - [x] 구현
 - [x] targeted test, lint, full test, build, fresh QA (`pass`)
-- [x] commit, push, Draft PR #42 갱신
+- [x] commit, push, Draft PR #43 생성

--- a/docs/exec-plans/active/2026-08-10-room-scrollbar-style/qa-report.md
+++ b/docs/exec-plans/active/2026-08-10-room-scrollbar-style/qa-report.md
@@ -1,0 +1,26 @@
+# QA Report
+
+## Result
+
+- fresh QA: `pass`
+- blocking findings: none
+
+## Verification
+
+- targeted: 2 files, 19 tests passed
+- full suite: 105 files, 323 tests passed
+- lint: passed
+- production build: passed
+- diff check: passed
+
+## Browser Boundary
+
+- Firefox: `scrollbar-width: thin`, 투명 track의 `scrollbar-color`
+- Chromium/Safari: 8px WebKit scrollbar, 투명 track/corner, 연한 둥근 thumb
+- Windows Chromium: scrollbar button을 `display: none`과 0 크기로 제거
+- 참가자 목록의 기존 scrollbar 완전 숨김 규칙 제거
+
+## Residual Risk
+
+- 실제 Windows Chrome/Edge/Firefox의 native 렌더링은 수동 확인하지 않았다.
+- Firefox의 세부 외형은 OS 접근성 및 스크롤바 설정에 따라 달라질 수 있다.

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,6 +1,6 @@
 # Active Execution Plans
 
-- [2026-08-10-room-scrollbar-style](./2026-08-10-room-scrollbar-style/plan.md): ci-pending — Draft PR #42, 채팅·참가자 목록 스크롤바 스타일 통일
+- [2026-08-10-room-scrollbar-style](./2026-08-10-room-scrollbar-style/plan.md): ci-pending — Draft PR #43, 채팅·참가자 목록 스크롤바 스타일 통일
 
 - [2026-08-10-chat-management-menu-layer](./2026-08-10-chat-management-menu-layer/plan.md): ci-pending — Draft PR #42, 채팅 관리 드롭다운 레이어 수정
 

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,5 +1,7 @@
 # Active Execution Plans
 
+- [2026-08-10-room-scrollbar-style](./2026-08-10-room-scrollbar-style/plan.md): ci-pending — Draft PR #42, 채팅·참가자 목록 스크롤바 스타일 통일
+
 - [2026-08-10-chat-management-menu-layer](./2026-08-10-chat-management-menu-layer/plan.md): ci-pending — Draft PR #42, 채팅 관리 드롭다운 레이어 수정
 
 - [2026-08-10-room-management-ui-fixes](./2026-08-10-room-management-ui-fixes/plan.md): ci-pending — Draft PR #42, 참가자 메뉴와 채팅 지연 피드백 정리

--- a/src/features/room/chat/ui/ChatArea.module.css
+++ b/src/features/room/chat/ui/ChatArea.module.css
@@ -17,6 +17,35 @@
   overflow-y: auto;
   overflow-anchor: none;
   overscroll-behavior: contain;
+  scrollbar-color: rgba(141, 141, 141, 0.34) transparent;
+  scrollbar-width: thin;
+}
+
+.list::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.list::-webkit-scrollbar-track,
+.list::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.list::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: rgba(141, 141, 141, 0.34);
+  background-clip: content-box;
+}
+
+.list::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(141, 141, 141, 0.5);
+}
+
+.list::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 .messages {

--- a/src/features/room/participants/ui/RoomParticipantsPanel.module.css
+++ b/src/features/room/participants/ui/RoomParticipantsPanel.module.css
@@ -42,12 +42,35 @@
   min-height: 0;
   margin-top: 16px;
   overflow-y: auto;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+  scrollbar-color: rgba(141, 141, 141, 0.34) transparent;
+  scrollbar-width: thin;
 }
 
 .list::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.list::-webkit-scrollbar-track,
+.list::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.list::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: rgba(141, 141, 141, 0.34);
+  background-clip: content-box;
+}
+
+.list::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(141, 141, 141, 0.5);
+}
+
+.list::-webkit-scrollbar-button {
   display: none;
+  width: 0;
+  height: 0;
 }
 
 .virtualList {


### PR DESCRIPTION
## 변경 내용

- 방 내부 채팅과 참가자 목록의 스크롤바 track/corner를 투명하게 변경했습니다.
- thumb를 얇고 연한 회색으로 통일하고 hover에서만 조금 진하게 표시합니다.
- Windows Chromium 계열의 스크롤바 화살표 버튼을 숨겼습니다.
- 참가자 목록에서 스크롤바를 완전히 숨기던 기존 규칙을 제거했습니다.

## 변경 이유

- 운영체제 기본 스크롤바의 진한 배경과 화살표가 방 내부 패널 디자인과 맞지 않았습니다.
- 채팅과 참가자 목록이 서로 다른 스크롤바 정책을 사용하고 있었습니다.

## 영향 범위

- [x] UI / 사용자 흐름
- [ ] API 요청·응답 계약
- [ ] React Query 캐시
- [ ] WebSocket / 실시간 상태
- [ ] 인증 / 보안
- [x] 문서 / 개발 도구

## 검증

- [x] `npm run lint`
- [x] `npm run test` — 105 files, 323 tests passed
- [x] `npm run build`
- [ ] 관련 수동 시나리오 확인
- [x] 실패·로딩·빈 상태 확인

## 리뷰 포인트

- Firefox의 `scrollbar-color/width`와 WebKit scrollbar pseudo-element가 같은 시각 의도를 유지하는지 확인해주세요.
- Windows Chrome/Edge에서 화살표 버튼이 숨겨지고 track이 투명하게 표시되는지 확인해주세요.

## 기능별 커밋

- `87aca31 style(room): 내부 목록 스크롤바 통일`

## 위험 및 후속 작업

- 실제 Windows 브라우저 수동 QA는 수행하지 않았습니다.
- Firefox 세부 외형은 OS 접근성 및 스크롤바 설정에 따라 조금 달라질 수 있습니다.

## 추적 정보

- Linked issue: 없음
- Execution plan: `docs/exec-plans/active/2026-08-10-room-scrollbar-style/`
- Selected skills: `queuing-feature-delivery`, `queuing-ui-flow`, `frontend-architecture-guardrails`, `queuing-qa-reviewer`
- QA result: `pass`
