### PR TITLE
test(room): 최신 UI 계약에 맞춰 CI 보정

### DIFF
--- a/docs/exec-plans/active/2026-08-12-edit-room-figma/delivery-state.md
+++ b/docs/exec-plans/active/2026-08-12-edit-room-figma/delivery-state.md
@@ -1,12 +1,12 @@
 # Delivery State
 
-- status: ready
+- status: ci-pending
 - branch: dev
 - base: main
 - issue:
-- pr: intentionally skipped
-- selected_skills: queuing-feature-delivery, queuing-orchestrator, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-qa-reviewer, browser:control-in-app-browser
-- local_qa: pass (`git diff --check`, `npm run lint`, `npm run build`, fresh read-only QA; tests intentionally skipped)
-- ci: not requested
+- pr: https://github.com/Queuing-org/frontend/pull/45
+- selected_skills: queuing-feature-delivery, queuing-orchestrator, queuing-api-boundary, queuing-ui-flow, frontend-architecture-guardrails, queuing-qa-reviewer, browser:control-in-app-browser, queuing-pr-review-cycle, gh-fix-ci
+- local_qa: pass (targeted 34 tests, full 114 files/389 tests, `npm run lint`, `npm run build`, fresh QA)
+- ci: pending rerun after fixing run 31584960055
 - review_threads: out of scope
-- next_action: 사용자 육안 확인
+- next_action: CI fix commit push 후 PR #45 check 재확인

--- a/docs/exec-plans/active/2026-08-12-edit-room-figma/qa-report.md
+++ b/docs/exec-plans/active/2026-08-12-edit-room-figma/qa-report.md
@@ -27,3 +27,18 @@
 
 - 공개 production OpenAPI endpoint가 노출되지 않아 PATCH의 `trackLimitMinutes` 필드는 현재 room meta/create 계약과 최신 제품 요구를 기준으로 연결했다.
 - 실제 signed-in room owner 상태의 modal과 최초 room join은 사용자 육안 확인이 필요하다.
+
+## CI Remediation QA
+
+- Classification: pass
+- Production source changes: none
+- Updated tests preserve the newest contracts:
+  - chat management menu remains open while its portal position follows scroll
+  - participant panel does not emit management feedback when no reportable chat exists
+  - edit modal uses the current `편집 완료` accessible name and isolates router/delete dependencies
+  - room join optimistically corrects the participant count and refetches room meta
+- Targeted affected suite: 5 files / 34 tests pass
+- Full suite: 114 files / 389 tests pass
+- `npm run lint`: pass
+- `npm run build`: pass
+- `git diff --check`: pass

--- a/docs/exec-plans/active/2026-08-12-edit-room-figma/review-findings.md
+++ b/docs/exec-plans/active/2026-08-12-edit-room-figma/review-findings.md
@@ -1,0 +1,38 @@
+# PR #45 Review Findings
+
+## CI Run
+
+- Workflow: `CI / Lint, test, and build`
+- Run: https://github.com/Queuing-org/frontend/actions/runs/31584960055
+- Head: `0ecca309f7fbf2d48e37b9f936d3d7464ece5c35`
+- Classification: actionable
+
+## Findings
+
+1. `ChatArea.test.tsx`
+   - 기존 테스트가 scroll 시 management menu가 닫힌다고 기대한다.
+   - 현재 승인된 portal 동작은 scroll 중 menu를 유지하고 위치를 추적한다.
+2. `RoomParticipantsPanel.test.tsx`
+   - 기존 테스트가 신고 가능한 채팅이 없을 때 panel 내부 안내 문구를 기대한다.
+   - 최신 요구는 참가자 panel 내부 관리 문구를 표시하지 않는 것이다.
+3. `RoomFormModal.test.tsx`
+   - edit submit button의 기존 accessible name `큐 수정하기`를 기대한다.
+   - 현재 UI label은 `편집 완료`다.
+4. `RoomPlaybackScreen.test.tsx`
+   - `next/navigation` mock에 `useRouter`가 없어서 render가 실패한다.
+   - 기존 테스트가 join 후 room meta 재조회를 하지 않는다고 기대하지만, 최초 0명 stale meta 보정을 위해 join 성공 후 재조회가 현재 계약이다.
+5. `EditRoomFormModal.test.tsx`
+   - 전체 local suite에서 새 router/delete dependency가 격리되지 않아 App Router invariant가 발생한다.
+   - edit form mock에 후속 track-limit return contract도 누락돼 있다.
+
+## Fix Scope
+
+- 위 네 test file의 mock과 expectation만 최신 제품 계약에 맞춘다.
+- production component/hook/CSS는 변경하지 않는다.
+
+## Resolution
+
+- Status: resolved locally
+- Targeted affected suite: 5 files / 34 tests pass
+- Full suite: 114 files / 389 tests pass
+- lint/build: pass

--- a/src/features/room/chat/ui/ChatArea.test.tsx
+++ b/src/features/room/chat/ui/ChatArea.test.tsx
@@ -337,7 +337,7 @@ describe("ChatArea 관리 메뉴", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("Escape, 바깥 클릭, 스크롤로 메뉴를 닫고 Escape는 포커스를 복원한다", async () => {
+  it("Escape와 바깥 클릭으로 닫고 스크롤 중에는 메뉴를 유지한다", async () => {
     const user = userEvent.setup();
     renderChat();
     const trigger = getMenuTrigger("회원");
@@ -353,7 +353,7 @@ describe("ChatArea 관리 메뉴", () => {
 
     await user.click(trigger);
     fireEvent.scroll(screen.getByLabelText("채팅 메시지 목록"));
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
   });
 
   it("신고·차단 메뉴를 모달에 연결하고 닫은 뒤 트리거 포커스를 복원한다", async () => {

--- a/src/features/room/create/ui/EditRoomFormModal.test.tsx
+++ b/src/features/room/create/ui/EditRoomFormModal.test.tsx
@@ -7,6 +7,17 @@ import EditRoomFormModal from "./EditRoomFormModal";
 vi.mock("@/src/features/room/update/hooks/useEditRoomForm", () => ({
   useEditRoomForm: vi.fn(),
 }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+vi.mock("@/src/features/room/update/model/useDeleteRoom", () => ({
+  useDeleteRoom: () => ({
+    error: null,
+    isPending: false,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
 vi.mock("@/src/features/room/hooks/useRoomTags", () => ({
   useRoomTags: () => ({ data: [] }),
 }));
@@ -40,11 +51,14 @@ describe("EditRoomFormModal feedback", () => {
       thumbnailPreviewUrl: null,
       thumbnailStatusMessage: null,
       title: "기존 방",
+      trackLimitMinutes: "",
+      trackLimitMinuteOptions: [5, 10, 15] as const,
       toggleTag: vi.fn(),
       markThumbnailPreviewUnavailable: vi.fn(),
       updateMaxParticipants: vi.fn(),
       updatePasswordChangeEnabled: vi.fn(),
       updatePasswordClearEnabled: vi.fn(),
+      updateTrackLimitMinutes: vi.fn(),
       updateTitle: vi.fn(),
     });
 

--- a/src/features/room/create/ui/RoomFormModal.test.tsx
+++ b/src/features/room/create/ui/RoomFormModal.test.tsx
@@ -573,7 +573,7 @@ describe("RoomFormModal room form flows", () => {
         file,
       });
     });
-    await userEvent.click(screen.getByRole("button", { name: "큐 수정하기" }));
+    await userEvent.click(screen.getByRole("button", { name: "편집 완료" }));
 
     await waitFor(() => {
       expect(vi.mocked(updateRoomThumbnail).mock.calls[0]?.[0]).toEqual({

--- a/src/features/room/page/ui/RoomPlaybackScreen.test.tsx
+++ b/src/features/room/page/ui/RoomPlaybackScreen.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
   const refetchParticipants = vi.fn();
   const ensureRoomSubscription = vi.fn();
   const leaveRoomSession = vi.fn();
+  const replace = vi.fn();
   const roomChat = {
     cleanupSubscriptions: vi.fn(),
     initializeFromJoinData: vi.fn(),
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => {
   return {
     ensureRoomSubscription,
     leaveRoomSession,
+    replace,
     refetchParticipants,
     refetchRoomPlayback,
     roomChat,
@@ -31,6 +33,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ slug: "room" }),
+  useRouter: () => ({ replace: mocks.replace }),
 }));
 vi.mock("@/src/shared/lib/useMediaQuery", () => ({
   useMediaQuery: () => false,
@@ -81,16 +84,19 @@ describe("RoomPlaybackScreen join reads", () => {
     localStorage.clear();
   });
 
-  it("pre-join meta를 query cache에 저장하고 joined 전환 시 warm read를 수동 refetch하지 않는다", async () => {
-    const roomMeta = {
+  it("pre-join meta를 저장하고 joined 전환 시 최신 인원 meta를 재조회한다", async () => {
+    const preJoinRoomMeta = {
       slug: "room",
       title: "방",
       isPublic: true,
       hasPassword: false,
-      activeUsersCount: 1,
+      activeUsersCount: 0,
       tags: [],
     };
-    vi.mocked(fetchRoomMeta).mockResolvedValue(roomMeta);
+    const joinedRoomMeta = { ...preJoinRoomMeta, activeUsersCount: 1 };
+    vi.mocked(fetchRoomMeta)
+      .mockResolvedValueOnce(preJoinRoomMeta)
+      .mockResolvedValueOnce(joinedRoomMeta);
     vi.mocked(joinRoom).mockResolvedValue({
       roomSlug: "room",
       timestamp: 1,
@@ -111,12 +117,20 @@ describe("RoomPlaybackScreen join reads", () => {
       expect(useRoomPlayback).toHaveBeenCalledWith("room", null, true),
     );
     expect(useRoomParticipants).toHaveBeenCalledWith("room", null, true);
-    expect(fetchRoomMeta).toHaveBeenCalledTimes(1);
-    expect(fetchRoomMeta).toHaveBeenCalledWith(
+    await waitFor(() => expect(fetchRoomMeta).toHaveBeenCalledTimes(2));
+    expect(fetchRoomMeta).toHaveBeenNthCalledWith(
+      1,
       "room",
       expect.any(AbortSignal),
     );
-    expect(queryClient.getQueryData(roomKeys.meta("room"))).toEqual(roomMeta);
+    expect(fetchRoomMeta).toHaveBeenNthCalledWith(
+      2,
+      "room",
+      expect.any(AbortSignal),
+    );
+    expect(queryClient.getQueryData(roomKeys.meta("room"))).toEqual(
+      joinedRoomMeta,
+    );
     expect(mocks.refetchRoomPlayback).not.toHaveBeenCalled();
     expect(mocks.refetchParticipants).not.toHaveBeenCalled();
 
@@ -163,6 +177,7 @@ describe("RoomPlaybackScreen join reads", () => {
     await act(async () => resolveRoomMeta(roomMeta));
 
     await waitFor(() => expect(joinRoom).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchRoomMeta).toHaveBeenCalledTimes(2));
     expect(sharedQuerySignal?.aborted).toBe(false);
 
     unmount();

--- a/src/features/room/participants/ui/RoomParticipantsPanel.test.tsx
+++ b/src/features/room/participants/ui/RoomParticipantsPanel.test.tsx
@@ -180,16 +180,17 @@ describe("RoomParticipantsPanel", () => {
     expect(onLoadMore).toHaveBeenCalledTimes(1);
   });
 
-  it("신고할 채팅이 없으면 요청 target 대신 안내를 표시한다", async () => {
+  it("신고할 채팅이 없으면 panel 안내 없이 요청을 무시한다", async () => {
     const user = userEvent.setup();
     renderPanel([]);
 
     await user.click(screen.getByRole("button", { name: "회원 신고" }));
 
     expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
     expect(
-      screen.getByText("신고할 수 있는 채팅 메시지가 없습니다."),
-    ).toBeVisible();
+      screen.queryByText("신고할 수 있는 채팅 메시지가 없습니다."),
+    ).toBeNull();
   });
 
   it("차단, 내보내기, 방장 위임을 기존 계약에 맞춰 연결한다", async () => {


### PR DESCRIPTION
## 변경 내용

- 최신 채팅 메뉴 동작에 맞춰 스크롤 테스트 계약을 보정함
- 참가자 패널, 방 수정 모달, 최초 입장 메타 동기화 테스트의 오래된 기대값과 mock을 수정함
- 기존 실패 6건을 재현하고 전체 테스트·lint·build를 통과시킴

## 변경 이유

- PR #45 머지 후 main CI에서 최신 제품 동작과 과거 테스트 계약이 어긋나 6개 테스트가 실패했음
- production 코드를 되돌리지 않고 현재 승인된 UI·상태 계약을 테스트에 정확히 반영해야 했음

## 영향 범위

- [x] UI / 사용자 흐름
- [ ] API 요청·응답 계약
- [ ] React Query 캐시
- [ ] WebSocket / 실시간 상태
- [ ] 인증 / 보안
- [x] 문서 / 개발 도구

## 검증

- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [ ] 관련 수동 시나리오 확인
- [x] 실패·로딩·빈 상태 확인

검증 결과 및 재현 방법:

- 대상 테스트 5 files / 34 tests 통과
- 전체 114 files / 389 tests 통과
- lint 및 production build 통과
- `git diff --check` 통과

## 리뷰 포인트

- production source 변경 없이 테스트 mock과 기대값만 최신 계약으로 변경했는지
- 채팅 메뉴는 스크롤 중 유지, 참가자 패널 내부 관리 문구는 미노출되는 계약이 반영됐는지
- 최초 입장 직후 room meta 재조회 및 0명 보정 계약이 반영됐는지

## 기능별 커밋

- `646affe test(room): 최신 UI 계약에 맞춰 CI 보정`

## 위험 및 후속 작업

- 실제 브라우저 UI 변경은 없음
- 이 PR의 Actions 결과 확인 필요

## 추적 정보

- Linked issue: 없음
- Execution plan: `docs/exec-plans/active/2026-08-12-edit-room-figma/`
- Selected skills: `queuing-pr-review-cycle`, `gh-fix-ci`, `queuing-ui-flow`, `frontend-architecture-guardrails`, `queuing-qa-reviewer`
- QA result: `pass`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * PR의 CI 수정 상태와 재실행 대기 정보를 업데이트했습니다.
  * 로컬 QA 결과, 테스트 범위 및 검증 항목을 기록했습니다.
  * CI 실패 원인과 해결 결과를 정리했습니다.

* **테스트**
  * 채팅 메뉴, 방 편집·삭제, 방 참여, 재생 화면, 참가자 패널 테스트를 현재 동작에 맞게 업데이트했습니다.
  * 관련 모킹과 접근성 검증을 보완했습니다.
  * 전체 테스트, lint 및 build 검증 결과를 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->